### PR TITLE
Remove unnecessary exception handling around function

### DIFF
--- a/dmn-core/src/main/java/com/gs/dmn/feel/lib/type/numeric/DoubleNumericType.java
+++ b/dmn-core/src/main/java/com/gs/dmn/feel/lib/type/numeric/DoubleNumericType.java
@@ -104,13 +104,7 @@ public class DoubleNumericType extends BaseType implements NumericType<Double> {
             return null;
         }
 
-        try {
-            return numericExponentiation(first, second.intValue());
-        } catch (Throwable e) {
-            String message = String.format("numericExponentiation(%s, %s)", first, second);
-            logError(message, e);
-            return null;
-        }
+        return numericExponentiation(first, second.intValue());
     }
 
     public Double numericExponentiation(Double first, int second) {


### PR DESCRIPTION
No longer necessary to handle exception in this situation.  

I verified the special cases to make sure intValue() doesn't throw a runtime exception
* NaN -> 0
* +ve Inf -> INT_MAX
* -ve Int -> INT_MIN

Also checked over/underflow and this doesn't cause any problem.  Incidentally - it does mean the following is true in Java: 
```
Assert.assertEquals(new Double(Integer.MAX_VALUE + 100.0).intValue(), Integer.MAX_VALUE);
```

Resolves #145 