### PR TITLE
Avoid using global python executable for TCK tests 

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -4,3 +4,5 @@ Licensed under Apache 2.0 license
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+This product contains code copyright Cerebral Adaptive Forecasting, licensed under Apache 2.0 license.

--- a/dco/cerebral-armins_stepanjans.dco
+++ b/dco/cerebral-armins_stepanjans.dco
@@ -1,0 +1,10 @@
+1) I, Armins Stepanjans, certify that all work committed with the commit message
+"covered by: cerebral-armins_stepanjans.dco" is copyright
+Cerebral Adaptive Forecasting and that I am authorized by Cerebral Adaptive Forecasting
+to contribute this code under the Apache 2.0 license.
+
+2) I understand and agree all contribution including all personal
+information I submit with it is maintained indefinitely and may be
+redistributed consistent with the open source license(s) involved.
+
+This certification is effective for all code contributed from 2023-12-04 to 9999-01-01.

--- a/dmn-tck-it/dmn-tck-it-python-translator/ci_build.sh
+++ b/dmn-tck-it/dmn-tck-it-python-translator/ci_build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 export CI_PROJECT_DIR=.
 
 # mvn clean does not remove them
@@ -5,7 +7,7 @@ rm -rf .pytest_cache
 rm -rf .tox
 rm -rf .venv
 
-$CI_PROJECT_DIR/ci/make_env.sh .venv
+source $CI_PROJECT_DIR/ci/make_env.sh .venv
 status=$?
 if [ $status -eq 0 ]
 then


### PR DESCRIPTION
Current ci_build.sh uses the global python executable. If pytest and flake8 are not globally installed `mvn test` will fail. This commit fixes that.