### PR TITLE
Junit 5 Upgrade

### DIFF
--- a/dco/cerebral-vincenzo_incutti.dco
+++ b/dco/cerebral-vincenzo_incutti.dco
@@ -1,0 +1,10 @@
+1) I, Vincenzo Incutti, certify that all work committed with the commit message
+"covered by: cerebral-vincenzo_incutti.dco" is copyright
+Cerebral Adaptive Forecasting and that I am authorized by Cerebral Adaptive Forecasting
+to contribute this code under the Apache 2.0 license.
+
+2) I understand and agree all contribution including all personal
+information I submit with it is maintained indefinitely and may be
+redistributed consistent with the open source license(s) involved.
+
+This certification is effective for all code contributed from 2024-06-24 to 9999-01-01.

--- a/dmn-core/pom.xml
+++ b/dmn-core/pom.xml
@@ -123,6 +123,12 @@
 			<version>5.10.1</version>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>commons-lang</groupId>

--- a/dmn-core/src/main/resources/templates/aws/pomFile.ftl
+++ b/dmn-core/src/main/resources/templates/aws/pomFile.ftl
@@ -76,8 +76,8 @@
            <scope>test</scope>
         </dependency>
         <dependency>
-           <groupId>org.junit.vintage</groupId>
-           <artifactId>junit-vintage-engine</artifactId>
+           <groupId>org.junit.jupiter</groupId>
+           <artifactId>junit-jupiter-engine</artifactId>
            <version>5.10.1</version>
            <scope>test</scope>
         </dependency>

--- a/dmn-core/src/main/resources/templates/tck/java/common/junit.ftl
+++ b/dmn-core/src/main/resources/templates/tck/java/common/junit.ftl
@@ -36,7 +36,7 @@ public class ${testClassName} extends ${decisionBaseClass} {
 <#macro addTestCases>
     <#list testCases.testCase>
         <#items as tc>
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase${tckUtil.testCaseId(tc)}() {
         <@initializeInputs tc/>
 

--- a/dmn-core/src/main/resources/templates/tck/kotlin/common/junit.ftl
+++ b/dmn-core/src/main/resources/templates/tck/kotlin/common/junit.ftl
@@ -24,7 +24,7 @@ class ${testClassName} : ${decisionBaseClass}() {
 <#macro addTestCases>
     <#list testCases.testCase>
         <#items as tc>
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase${tc.id}() {
         <@initializeInputs tc/>
 

--- a/dmn-runtime/pom.xml
+++ b/dmn-runtime/pom.xml
@@ -121,8 +121,8 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/dmn-signavio-it/dmn-signavio-it-kotlin-translator/src/test/resources/traces/example_credit_decision/50-25-postorder-with-filter.json
+++ b/dmn-signavio-it/dmn-signavio-it-kotlin-translator/src/test/resources/traces/example_credit_decision/50-25-postorder-with-filter.json
@@ -47,7 +47,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -64,7 +64,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {

--- a/dmn-signavio-it/dmn-signavio-it-kotlin-translator/src/test/resources/traces/example_credit_decision/50-25-postorder.json
+++ b/dmn-signavio-it/dmn-signavio-it-kotlin-translator/src/test/resources/traces/example_credit_decision/50-25-postorder.json
@@ -27,7 +27,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -44,7 +44,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -61,7 +61,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -78,7 +78,7 @@
       {
         "rule": {
           "index": 4,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -95,7 +95,7 @@
       {
         "rule": {
           "index": 5,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -198,7 +198,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -215,7 +215,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -232,7 +232,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -276,7 +276,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -362,7 +362,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -379,7 +379,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -424,7 +424,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -441,7 +441,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -458,7 +458,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -475,7 +475,7 @@
       {
         "rule": {
           "index": 4,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -492,7 +492,7 @@
       {
         "rule": {
           "index": 5,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -595,7 +595,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -612,7 +612,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -629,7 +629,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -673,7 +673,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -735,7 +735,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -752,7 +752,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -769,7 +769,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -786,7 +786,7 @@
       {
         "rule": {
           "index": 4,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -803,7 +803,7 @@
       {
         "rule": {
           "index": 5,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {

--- a/dmn-signavio-it/dmn-signavio-it-kotlin-translator/src/test/resources/traces/example_credit_decision/50-25-tree-postorder.json
+++ b/dmn-signavio-it/dmn-signavio-it-kotlin-translator/src/test/resources/traces/example_credit_decision/50-25-tree-postorder.json
@@ -27,7 +27,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -44,7 +44,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -61,7 +61,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -78,7 +78,7 @@
       {
         "rule": {
           "index": 4,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -95,7 +95,7 @@
       {
         "rule": {
           "index": 5,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -200,7 +200,7 @@
           {
             "rule": {
               "index": 1,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -217,7 +217,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -234,7 +234,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -251,7 +251,7 @@
           {
             "rule": {
               "index": 4,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -268,7 +268,7 @@
           {
             "rule": {
               "index": 5,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -348,7 +348,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -365,7 +365,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -382,7 +382,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -426,7 +426,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -515,7 +515,7 @@
               {
                 "rule": {
                   "index": 1,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -532,7 +532,7 @@
               {
                 "rule": {
                   "index": 2,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -549,7 +549,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -566,7 +566,7 @@
               {
                 "rule": {
                   "index": 4,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -583,7 +583,7 @@
               {
                 "rule": {
                   "index": 5,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -663,7 +663,7 @@
           {
             "rule": {
               "index": 1,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -680,7 +680,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -697,7 +697,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -764,7 +764,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -781,7 +781,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -824,7 +824,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -913,7 +913,7 @@
                   {
                     "rule": {
                       "index": 1,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": true,
                     "result": {
@@ -930,7 +930,7 @@
                   {
                     "rule": {
                       "index": 2,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -947,7 +947,7 @@
                   {
                     "rule": {
                       "index": 3,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -964,7 +964,7 @@
                   {
                     "rule": {
                       "index": 4,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -981,7 +981,7 @@
                   {
                     "rule": {
                       "index": 5,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": true,
                     "result": {
@@ -1061,7 +1061,7 @@
               {
                 "rule": {
                   "index": 1,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -1078,7 +1078,7 @@
               {
                 "rule": {
                   "index": 2,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -1095,7 +1095,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -1144,7 +1144,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -1161,7 +1161,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1178,7 +1178,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1195,7 +1195,7 @@
       {
         "rule": {
           "index": 4,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1212,7 +1212,7 @@
       {
         "rule": {
           "index": 5,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -1317,7 +1317,7 @@
           {
             "rule": {
               "index": 1,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -1334,7 +1334,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -1351,7 +1351,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -1368,7 +1368,7 @@
           {
             "rule": {
               "index": 4,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -1385,7 +1385,7 @@
           {
             "rule": {
               "index": 5,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -1465,7 +1465,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1482,7 +1482,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1499,7 +1499,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -1543,7 +1543,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -1628,7 +1628,7 @@
               {
                 "rule": {
                   "index": 1,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -1645,7 +1645,7 @@
               {
                 "rule": {
                   "index": 2,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -1662,7 +1662,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -1679,7 +1679,7 @@
               {
                 "rule": {
                   "index": 4,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -1696,7 +1696,7 @@
               {
                 "rule": {
                   "index": 5,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -1776,7 +1776,7 @@
           {
             "rule": {
               "index": 1,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -1793,7 +1793,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -1810,7 +1810,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -1857,7 +1857,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -1874,7 +1874,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1891,7 +1891,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1908,7 +1908,7 @@
       {
         "rule": {
           "index": 4,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1925,7 +1925,7 @@
       {
         "rule": {
           "index": 5,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -2030,7 +2030,7 @@
           {
             "rule": {
               "index": 1,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -2047,7 +2047,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2064,7 +2064,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2081,7 +2081,7 @@
           {
             "rule": {
               "index": 4,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2098,7 +2098,7 @@
           {
             "rule": {
               "index": 5,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -2232,7 +2232,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2249,7 +2249,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -2292,7 +2292,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -2381,7 +2381,7 @@
                       {
                         "rule": {
                           "index": 1,
-                          "annotation": "\"\""
+                          "annotation": ""
                         },
                         "matched": true,
                         "result": {
@@ -2398,7 +2398,7 @@
                       {
                         "rule": {
                           "index": 2,
-                          "annotation": "\"\""
+                          "annotation": ""
                         },
                         "matched": false,
                         "result": {
@@ -2415,7 +2415,7 @@
                       {
                         "rule": {
                           "index": 3,
-                          "annotation": "\"\""
+                          "annotation": ""
                         },
                         "matched": false,
                         "result": {
@@ -2432,7 +2432,7 @@
                       {
                         "rule": {
                           "index": 4,
-                          "annotation": "\"\""
+                          "annotation": ""
                         },
                         "matched": false,
                         "result": {
@@ -2449,7 +2449,7 @@
                       {
                         "rule": {
                           "index": 5,
-                          "annotation": "\"\""
+                          "annotation": ""
                         },
                         "matched": true,
                         "result": {
@@ -2529,7 +2529,7 @@
                   {
                     "rule": {
                       "index": 1,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -2546,7 +2546,7 @@
                   {
                     "rule": {
                       "index": 2,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -2563,7 +2563,7 @@
                   {
                     "rule": {
                       "index": 3,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": true,
                     "result": {
@@ -2611,7 +2611,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -2696,7 +2696,7 @@
                   {
                     "rule": {
                       "index": 1,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": true,
                     "result": {
@@ -2713,7 +2713,7 @@
                   {
                     "rule": {
                       "index": 2,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -2730,7 +2730,7 @@
                   {
                     "rule": {
                       "index": 3,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -2747,7 +2747,7 @@
                   {
                     "rule": {
                       "index": 4,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -2764,7 +2764,7 @@
                   {
                     "rule": {
                       "index": 5,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": true,
                     "result": {
@@ -2844,7 +2844,7 @@
               {
                 "rule": {
                   "index": 1,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -2861,7 +2861,7 @@
               {
                 "rule": {
                   "index": 2,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -2878,7 +2878,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -2949,7 +2949,7 @@
               {
                 "rule": {
                   "index": 1,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -2966,7 +2966,7 @@
               {
                 "rule": {
                   "index": 2,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -2983,7 +2983,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -3000,7 +3000,7 @@
               {
                 "rule": {
                   "index": 4,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -3017,7 +3017,7 @@
               {
                 "rule": {
                   "index": 5,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {

--- a/dmn-signavio-it/dmn-signavio-it-kotlin-translator/src/test/resources/traces/example_credit_decision/50-25-tree-preorder.json
+++ b/dmn-signavio-it/dmn-signavio-it-kotlin-translator/src/test/resources/traces/example_credit_decision/50-25-tree-preorder.json
@@ -78,7 +78,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -95,7 +95,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -138,7 +138,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -227,7 +227,7 @@
                       {
                         "rule": {
                           "index": 1,
-                          "annotation": "\"\""
+                          "annotation": ""
                         },
                         "matched": true,
                         "result": {
@@ -244,7 +244,7 @@
                       {
                         "rule": {
                           "index": 2,
-                          "annotation": "\"\""
+                          "annotation": ""
                         },
                         "matched": false,
                         "result": {
@@ -261,7 +261,7 @@
                       {
                         "rule": {
                           "index": 3,
-                          "annotation": "\"\""
+                          "annotation": ""
                         },
                         "matched": false,
                         "result": {
@@ -278,7 +278,7 @@
                       {
                         "rule": {
                           "index": 4,
-                          "annotation": "\"\""
+                          "annotation": ""
                         },
                         "matched": false,
                         "result": {
@@ -295,7 +295,7 @@
                       {
                         "rule": {
                           "index": 5,
-                          "annotation": "\"\""
+                          "annotation": ""
                         },
                         "matched": true,
                         "result": {
@@ -375,7 +375,7 @@
                   {
                     "rule": {
                       "index": 1,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -392,7 +392,7 @@
                   {
                     "rule": {
                       "index": 2,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -409,7 +409,7 @@
                   {
                     "rule": {
                       "index": 3,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": true,
                     "result": {
@@ -457,7 +457,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -542,7 +542,7 @@
                   {
                     "rule": {
                       "index": 1,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": true,
                     "result": {
@@ -559,7 +559,7 @@
                   {
                     "rule": {
                       "index": 2,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -576,7 +576,7 @@
                   {
                     "rule": {
                       "index": 3,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -593,7 +593,7 @@
                   {
                     "rule": {
                       "index": 4,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -610,7 +610,7 @@
                   {
                     "rule": {
                       "index": 5,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": true,
                     "result": {
@@ -690,7 +690,7 @@
               {
                 "rule": {
                   "index": 1,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -707,7 +707,7 @@
               {
                 "rule": {
                   "index": 2,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -724,7 +724,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -795,7 +795,7 @@
               {
                 "rule": {
                   "index": 1,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -812,7 +812,7 @@
               {
                 "rule": {
                   "index": 2,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -829,7 +829,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -846,7 +846,7 @@
               {
                 "rule": {
                   "index": 4,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -863,7 +863,7 @@
               {
                 "rule": {
                   "index": 5,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -968,7 +968,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -985,7 +985,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -1028,7 +1028,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -1117,7 +1117,7 @@
                   {
                     "rule": {
                       "index": 1,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": true,
                     "result": {
@@ -1134,7 +1134,7 @@
                   {
                     "rule": {
                       "index": 2,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -1151,7 +1151,7 @@
                   {
                     "rule": {
                       "index": 3,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -1168,7 +1168,7 @@
                   {
                     "rule": {
                       "index": 4,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -1185,7 +1185,7 @@
                   {
                     "rule": {
                       "index": 5,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": true,
                     "result": {
@@ -1265,7 +1265,7 @@
               {
                 "rule": {
                   "index": 1,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -1282,7 +1282,7 @@
               {
                 "rule": {
                   "index": 2,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -1299,7 +1299,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -1347,7 +1347,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -1436,7 +1436,7 @@
               {
                 "rule": {
                   "index": 1,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -1453,7 +1453,7 @@
               {
                 "rule": {
                   "index": 2,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -1470,7 +1470,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -1487,7 +1487,7 @@
               {
                 "rule": {
                   "index": 4,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -1504,7 +1504,7 @@
               {
                 "rule": {
                   "index": 5,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -1584,7 +1584,7 @@
           {
             "rule": {
               "index": 1,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -1601,7 +1601,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -1618,7 +1618,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -1689,7 +1689,7 @@
           {
             "rule": {
               "index": 1,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -1706,7 +1706,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -1723,7 +1723,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -1740,7 +1740,7 @@
           {
             "rule": {
               "index": 4,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -1757,7 +1757,7 @@
           {
             "rule": {
               "index": 5,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -1840,7 +1840,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -1857,7 +1857,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1874,7 +1874,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1891,7 +1891,7 @@
       {
         "rule": {
           "index": 4,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1908,7 +1908,7 @@
       {
         "rule": {
           "index": 5,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -1986,7 +1986,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -2003,7 +2003,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -2020,7 +2020,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -2064,7 +2064,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -2149,7 +2149,7 @@
               {
                 "rule": {
                   "index": 1,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -2166,7 +2166,7 @@
               {
                 "rule": {
                   "index": 2,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -2183,7 +2183,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -2200,7 +2200,7 @@
               {
                 "rule": {
                   "index": 4,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -2217,7 +2217,7 @@
               {
                 "rule": {
                   "index": 5,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -2297,7 +2297,7 @@
           {
             "rule": {
               "index": 1,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2314,7 +2314,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2331,7 +2331,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -2402,7 +2402,7 @@
           {
             "rule": {
               "index": 1,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -2419,7 +2419,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2436,7 +2436,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2453,7 +2453,7 @@
           {
             "rule": {
               "index": 4,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2470,7 +2470,7 @@
           {
             "rule": {
               "index": 5,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -2553,7 +2553,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -2570,7 +2570,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -2587,7 +2587,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -2604,7 +2604,7 @@
       {
         "rule": {
           "index": 4,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -2621,7 +2621,7 @@
       {
         "rule": {
           "index": 5,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -2699,7 +2699,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -2716,7 +2716,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -2733,7 +2733,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -2802,7 +2802,7 @@
           {
             "rule": {
               "index": 1,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -2819,7 +2819,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2836,7 +2836,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2853,7 +2853,7 @@
           {
             "rule": {
               "index": 4,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2870,7 +2870,7 @@
           {
             "rule": {
               "index": 5,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -2953,7 +2953,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -2970,7 +2970,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -2987,7 +2987,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -3004,7 +3004,7 @@
       {
         "rule": {
           "index": 4,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -3021,7 +3021,7 @@
       {
         "rule": {
           "index": 5,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {

--- a/dmn-signavio-it/dmn-signavio-it-kotlin-translator/src/test/resources/traces/example_credit_decision/50-25-tree.json
+++ b/dmn-signavio-it/dmn-signavio-it-kotlin-translator/src/test/resources/traces/example_credit_decision/50-25-tree.json
@@ -77,7 +77,7 @@
         {
           "rule": {
             "index": 2,
-            "annotation": "\"\""
+            "annotation": ""
           },
           "matched": false,
           "result": {
@@ -94,7 +94,7 @@
         {
           "rule": {
             "index": 3,
-            "annotation": "\"\""
+            "annotation": ""
           },
           "matched": true,
           "result": {
@@ -137,7 +137,7 @@
             {
               "rule": {
                 "index": 3,
-                "annotation": "\"\""
+                "annotation": ""
               },
               "matched": true,
               "result": {
@@ -226,7 +226,7 @@
                     {
                       "rule": {
                         "index": 1,
-                        "annotation": "\"\""
+                        "annotation": ""
                       },
                       "matched": true,
                       "result": {
@@ -243,7 +243,7 @@
                     {
                       "rule": {
                         "index": 2,
-                        "annotation": "\"\""
+                        "annotation": ""
                       },
                       "matched": false,
                       "result": {
@@ -260,7 +260,7 @@
                     {
                       "rule": {
                         "index": 3,
-                        "annotation": "\"\""
+                        "annotation": ""
                       },
                       "matched": false,
                       "result": {
@@ -277,7 +277,7 @@
                     {
                       "rule": {
                         "index": 4,
-                        "annotation": "\"\""
+                        "annotation": ""
                       },
                       "matched": false,
                       "result": {
@@ -294,7 +294,7 @@
                     {
                       "rule": {
                         "index": 5,
-                        "annotation": "\"\""
+                        "annotation": ""
                       },
                       "matched": true,
                       "result": {
@@ -374,7 +374,7 @@
                 {
                   "rule": {
                     "index": 1,
-                    "annotation": "\"\""
+                    "annotation": ""
                   },
                   "matched": false,
                   "result": {
@@ -391,7 +391,7 @@
                 {
                   "rule": {
                     "index": 2,
-                    "annotation": "\"\""
+                    "annotation": ""
                   },
                   "matched": false,
                   "result": {
@@ -408,7 +408,7 @@
                 {
                   "rule": {
                     "index": 3,
-                    "annotation": "\"\""
+                    "annotation": ""
                   },
                   "matched": true,
                   "result": {
@@ -456,7 +456,7 @@
         {
           "rule": {
             "index": 3,
-            "annotation": "\"\""
+            "annotation": ""
           },
           "matched": true,
           "result": {
@@ -541,7 +541,7 @@
                 {
                   "rule": {
                     "index": 1,
-                    "annotation": "\"\""
+                    "annotation": ""
                   },
                   "matched": true,
                   "result": {
@@ -558,7 +558,7 @@
                 {
                   "rule": {
                     "index": 2,
-                    "annotation": "\"\""
+                    "annotation": ""
                   },
                   "matched": false,
                   "result": {
@@ -575,7 +575,7 @@
                 {
                   "rule": {
                     "index": 3,
-                    "annotation": "\"\""
+                    "annotation": ""
                   },
                   "matched": false,
                   "result": {
@@ -592,7 +592,7 @@
                 {
                   "rule": {
                     "index": 4,
-                    "annotation": "\"\""
+                    "annotation": ""
                   },
                   "matched": false,
                   "result": {
@@ -609,7 +609,7 @@
                 {
                   "rule": {
                     "index": 5,
-                    "annotation": "\"\""
+                    "annotation": ""
                   },
                   "matched": true,
                   "result": {
@@ -689,7 +689,7 @@
             {
               "rule": {
                 "index": 1,
-                "annotation": "\"\""
+                "annotation": ""
               },
               "matched": false,
               "result": {
@@ -706,7 +706,7 @@
             {
               "rule": {
                 "index": 2,
-                "annotation": "\"\""
+                "annotation": ""
               },
               "matched": false,
               "result": {
@@ -723,7 +723,7 @@
             {
               "rule": {
                 "index": 3,
-                "annotation": "\"\""
+                "annotation": ""
               },
               "matched": true,
               "result": {
@@ -794,7 +794,7 @@
             {
               "rule": {
                 "index": 1,
-                "annotation": "\"\""
+                "annotation": ""
               },
               "matched": true,
               "result": {
@@ -811,7 +811,7 @@
             {
               "rule": {
                 "index": 2,
-                "annotation": "\"\""
+                "annotation": ""
               },
               "matched": false,
               "result": {
@@ -828,7 +828,7 @@
             {
               "rule": {
                 "index": 3,
-                "annotation": "\"\""
+                "annotation": ""
               },
               "matched": false,
               "result": {
@@ -845,7 +845,7 @@
             {
               "rule": {
                 "index": 4,
-                "annotation": "\"\""
+                "annotation": ""
               },
               "matched": false,
               "result": {
@@ -862,7 +862,7 @@
             {
               "rule": {
                 "index": 5,
-                "annotation": "\"\""
+                "annotation": ""
               },
               "matched": true,
               "result": {

--- a/dmn-signavio-it/dmn-signavio-it-translator/src/test/java/com/gs/dmn/generated/sd_feel_date_literal_expression/HandwrittenDecisionTest.java
+++ b/dmn-signavio-it/dmn-signavio-it-translator/src/test/java/com/gs/dmn/generated/sd_feel_date_literal_expression/HandwrittenDecisionTest.java
@@ -34,10 +34,8 @@ public class HandwrittenDecisionTest extends AbstractHandwrittenDecisionTest {
     @Test
     public void testApplyWhenNull() {
         Assertions.assertThrows(NullPointerException.class, () -> {
-            Assertions.assertThrows(NullPointerException.class, () -> {
-                BigDecimal output = applyDecision(null, null, null, null, null);
-                assertEquals(29, output.intValue());
-            });
+            BigDecimal output = applyDecision(null, null, null, null, null);
+            assertEquals(29, output.intValue());
         });
     }
 

--- a/dmn-signavio-it/dmn-signavio-it-translator/src/test/resources/traces/example_credit_decision/50-25-postorder-with-filter.json
+++ b/dmn-signavio-it/dmn-signavio-it-translator/src/test/resources/traces/example_credit_decision/50-25-postorder-with-filter.json
@@ -47,7 +47,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -64,7 +64,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {

--- a/dmn-signavio-it/dmn-signavio-it-translator/src/test/resources/traces/example_credit_decision/50-25-postorder.json
+++ b/dmn-signavio-it/dmn-signavio-it-translator/src/test/resources/traces/example_credit_decision/50-25-postorder.json
@@ -27,7 +27,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -44,7 +44,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -61,7 +61,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -78,7 +78,7 @@
       {
         "rule": {
           "index": 4,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -95,7 +95,7 @@
       {
         "rule": {
           "index": 5,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -198,7 +198,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -215,7 +215,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -232,7 +232,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -276,7 +276,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -362,7 +362,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -379,7 +379,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -424,7 +424,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -441,7 +441,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -458,7 +458,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -475,7 +475,7 @@
       {
         "rule": {
           "index": 4,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -492,7 +492,7 @@
       {
         "rule": {
           "index": 5,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -595,7 +595,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -612,7 +612,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -629,7 +629,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -673,7 +673,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -735,7 +735,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -752,7 +752,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -769,7 +769,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -786,7 +786,7 @@
       {
         "rule": {
           "index": 4,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -803,7 +803,7 @@
       {
         "rule": {
           "index": 5,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {

--- a/dmn-signavio-it/dmn-signavio-it-translator/src/test/resources/traces/example_credit_decision/50-25-tree-postorder.json
+++ b/dmn-signavio-it/dmn-signavio-it-translator/src/test/resources/traces/example_credit_decision/50-25-tree-postorder.json
@@ -27,7 +27,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -44,7 +44,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -61,7 +61,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -78,7 +78,7 @@
       {
         "rule": {
           "index": 4,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -95,7 +95,7 @@
       {
         "rule": {
           "index": 5,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -200,7 +200,7 @@
           {
             "rule": {
               "index": 1,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -217,7 +217,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -234,7 +234,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -251,7 +251,7 @@
           {
             "rule": {
               "index": 4,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -268,7 +268,7 @@
           {
             "rule": {
               "index": 5,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -348,7 +348,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -365,7 +365,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -382,7 +382,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -426,7 +426,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -515,7 +515,7 @@
               {
                 "rule": {
                   "index": 1,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -532,7 +532,7 @@
               {
                 "rule": {
                   "index": 2,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -549,7 +549,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -566,7 +566,7 @@
               {
                 "rule": {
                   "index": 4,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -583,7 +583,7 @@
               {
                 "rule": {
                   "index": 5,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -663,7 +663,7 @@
           {
             "rule": {
               "index": 1,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -680,7 +680,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -697,7 +697,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -764,7 +764,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -781,7 +781,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -824,7 +824,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -913,7 +913,7 @@
                   {
                     "rule": {
                       "index": 1,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": true,
                     "result": {
@@ -930,7 +930,7 @@
                   {
                     "rule": {
                       "index": 2,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -947,7 +947,7 @@
                   {
                     "rule": {
                       "index": 3,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -964,7 +964,7 @@
                   {
                     "rule": {
                       "index": 4,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -981,7 +981,7 @@
                   {
                     "rule": {
                       "index": 5,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": true,
                     "result": {
@@ -1061,7 +1061,7 @@
               {
                 "rule": {
                   "index": 1,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -1078,7 +1078,7 @@
               {
                 "rule": {
                   "index": 2,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -1095,7 +1095,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -1144,7 +1144,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -1161,7 +1161,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1178,7 +1178,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1195,7 +1195,7 @@
       {
         "rule": {
           "index": 4,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1212,7 +1212,7 @@
       {
         "rule": {
           "index": 5,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -1317,7 +1317,7 @@
           {
             "rule": {
               "index": 1,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -1334,7 +1334,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -1351,7 +1351,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -1368,7 +1368,7 @@
           {
             "rule": {
               "index": 4,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -1385,7 +1385,7 @@
           {
             "rule": {
               "index": 5,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -1465,7 +1465,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1482,7 +1482,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1499,7 +1499,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -1543,7 +1543,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -1628,7 +1628,7 @@
               {
                 "rule": {
                   "index": 1,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -1645,7 +1645,7 @@
               {
                 "rule": {
                   "index": 2,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -1662,7 +1662,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -1679,7 +1679,7 @@
               {
                 "rule": {
                   "index": 4,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -1696,7 +1696,7 @@
               {
                 "rule": {
                   "index": 5,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -1776,7 +1776,7 @@
           {
             "rule": {
               "index": 1,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -1793,7 +1793,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -1810,7 +1810,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -1857,7 +1857,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -1874,7 +1874,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1891,7 +1891,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1908,7 +1908,7 @@
       {
         "rule": {
           "index": 4,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1925,7 +1925,7 @@
       {
         "rule": {
           "index": 5,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -2030,7 +2030,7 @@
           {
             "rule": {
               "index": 1,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -2047,7 +2047,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2064,7 +2064,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2081,7 +2081,7 @@
           {
             "rule": {
               "index": 4,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2098,7 +2098,7 @@
           {
             "rule": {
               "index": 5,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -2232,7 +2232,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2249,7 +2249,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -2292,7 +2292,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -2381,7 +2381,7 @@
                       {
                         "rule": {
                           "index": 1,
-                          "annotation": "\"\""
+                          "annotation": ""
                         },
                         "matched": true,
                         "result": {
@@ -2398,7 +2398,7 @@
                       {
                         "rule": {
                           "index": 2,
-                          "annotation": "\"\""
+                          "annotation": ""
                         },
                         "matched": false,
                         "result": {
@@ -2415,7 +2415,7 @@
                       {
                         "rule": {
                           "index": 3,
-                          "annotation": "\"\""
+                          "annotation": ""
                         },
                         "matched": false,
                         "result": {
@@ -2432,7 +2432,7 @@
                       {
                         "rule": {
                           "index": 4,
-                          "annotation": "\"\""
+                          "annotation": ""
                         },
                         "matched": false,
                         "result": {
@@ -2449,7 +2449,7 @@
                       {
                         "rule": {
                           "index": 5,
-                          "annotation": "\"\""
+                          "annotation": ""
                         },
                         "matched": true,
                         "result": {
@@ -2529,7 +2529,7 @@
                   {
                     "rule": {
                       "index": 1,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -2546,7 +2546,7 @@
                   {
                     "rule": {
                       "index": 2,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -2563,7 +2563,7 @@
                   {
                     "rule": {
                       "index": 3,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": true,
                     "result": {
@@ -2611,7 +2611,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -2696,7 +2696,7 @@
                   {
                     "rule": {
                       "index": 1,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": true,
                     "result": {
@@ -2713,7 +2713,7 @@
                   {
                     "rule": {
                       "index": 2,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -2730,7 +2730,7 @@
                   {
                     "rule": {
                       "index": 3,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -2747,7 +2747,7 @@
                   {
                     "rule": {
                       "index": 4,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -2764,7 +2764,7 @@
                   {
                     "rule": {
                       "index": 5,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": true,
                     "result": {
@@ -2844,7 +2844,7 @@
               {
                 "rule": {
                   "index": 1,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -2861,7 +2861,7 @@
               {
                 "rule": {
                   "index": 2,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -2878,7 +2878,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -2949,7 +2949,7 @@
               {
                 "rule": {
                   "index": 1,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -2966,7 +2966,7 @@
               {
                 "rule": {
                   "index": 2,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -2983,7 +2983,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -3000,7 +3000,7 @@
               {
                 "rule": {
                   "index": 4,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -3017,7 +3017,7 @@
               {
                 "rule": {
                   "index": 5,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {

--- a/dmn-signavio-it/dmn-signavio-it-translator/src/test/resources/traces/example_credit_decision/50-25-tree-preorder.json
+++ b/dmn-signavio-it/dmn-signavio-it-translator/src/test/resources/traces/example_credit_decision/50-25-tree-preorder.json
@@ -78,7 +78,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -95,7 +95,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -138,7 +138,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -227,7 +227,7 @@
                       {
                         "rule": {
                           "index": 1,
-                          "annotation": "\"\""
+                          "annotation": ""
                         },
                         "matched": true,
                         "result": {
@@ -244,7 +244,7 @@
                       {
                         "rule": {
                           "index": 2,
-                          "annotation": "\"\""
+                          "annotation": ""
                         },
                         "matched": false,
                         "result": {
@@ -261,7 +261,7 @@
                       {
                         "rule": {
                           "index": 3,
-                          "annotation": "\"\""
+                          "annotation": ""
                         },
                         "matched": false,
                         "result": {
@@ -278,7 +278,7 @@
                       {
                         "rule": {
                           "index": 4,
-                          "annotation": "\"\""
+                          "annotation": ""
                         },
                         "matched": false,
                         "result": {
@@ -295,7 +295,7 @@
                       {
                         "rule": {
                           "index": 5,
-                          "annotation": "\"\""
+                          "annotation": ""
                         },
                         "matched": true,
                         "result": {
@@ -375,7 +375,7 @@
                   {
                     "rule": {
                       "index": 1,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -392,7 +392,7 @@
                   {
                     "rule": {
                       "index": 2,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -409,7 +409,7 @@
                   {
                     "rule": {
                       "index": 3,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": true,
                     "result": {
@@ -457,7 +457,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -542,7 +542,7 @@
                   {
                     "rule": {
                       "index": 1,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": true,
                     "result": {
@@ -559,7 +559,7 @@
                   {
                     "rule": {
                       "index": 2,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -576,7 +576,7 @@
                   {
                     "rule": {
                       "index": 3,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -593,7 +593,7 @@
                   {
                     "rule": {
                       "index": 4,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -610,7 +610,7 @@
                   {
                     "rule": {
                       "index": 5,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": true,
                     "result": {
@@ -690,7 +690,7 @@
               {
                 "rule": {
                   "index": 1,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -707,7 +707,7 @@
               {
                 "rule": {
                   "index": 2,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -724,7 +724,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -795,7 +795,7 @@
               {
                 "rule": {
                   "index": 1,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -812,7 +812,7 @@
               {
                 "rule": {
                   "index": 2,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -829,7 +829,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -846,7 +846,7 @@
               {
                 "rule": {
                   "index": 4,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -863,7 +863,7 @@
               {
                 "rule": {
                   "index": 5,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -968,7 +968,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -985,7 +985,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -1028,7 +1028,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -1117,7 +1117,7 @@
                   {
                     "rule": {
                       "index": 1,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": true,
                     "result": {
@@ -1134,7 +1134,7 @@
                   {
                     "rule": {
                       "index": 2,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -1151,7 +1151,7 @@
                   {
                     "rule": {
                       "index": 3,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -1168,7 +1168,7 @@
                   {
                     "rule": {
                       "index": 4,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": false,
                     "result": {
@@ -1185,7 +1185,7 @@
                   {
                     "rule": {
                       "index": 5,
-                      "annotation": "\"\""
+                      "annotation": ""
                     },
                     "matched": true,
                     "result": {
@@ -1265,7 +1265,7 @@
               {
                 "rule": {
                   "index": 1,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -1282,7 +1282,7 @@
               {
                 "rule": {
                   "index": 2,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -1299,7 +1299,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -1347,7 +1347,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -1436,7 +1436,7 @@
               {
                 "rule": {
                   "index": 1,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -1453,7 +1453,7 @@
               {
                 "rule": {
                   "index": 2,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -1470,7 +1470,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -1487,7 +1487,7 @@
               {
                 "rule": {
                   "index": 4,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -1504,7 +1504,7 @@
               {
                 "rule": {
                   "index": 5,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -1584,7 +1584,7 @@
           {
             "rule": {
               "index": 1,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -1601,7 +1601,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -1618,7 +1618,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -1689,7 +1689,7 @@
           {
             "rule": {
               "index": 1,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -1706,7 +1706,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -1723,7 +1723,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -1740,7 +1740,7 @@
           {
             "rule": {
               "index": 4,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -1757,7 +1757,7 @@
           {
             "rule": {
               "index": 5,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -1840,7 +1840,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -1857,7 +1857,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1874,7 +1874,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1891,7 +1891,7 @@
       {
         "rule": {
           "index": 4,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -1908,7 +1908,7 @@
       {
         "rule": {
           "index": 5,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -1986,7 +1986,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -2003,7 +2003,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -2020,7 +2020,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -2064,7 +2064,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -2149,7 +2149,7 @@
               {
                 "rule": {
                   "index": 1,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -2166,7 +2166,7 @@
               {
                 "rule": {
                   "index": 2,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -2183,7 +2183,7 @@
               {
                 "rule": {
                   "index": 3,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -2200,7 +2200,7 @@
               {
                 "rule": {
                   "index": 4,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": false,
                 "result": {
@@ -2217,7 +2217,7 @@
               {
                 "rule": {
                   "index": 5,
-                  "annotation": "\"\""
+                  "annotation": ""
                 },
                 "matched": true,
                 "result": {
@@ -2297,7 +2297,7 @@
           {
             "rule": {
               "index": 1,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2314,7 +2314,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2331,7 +2331,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -2402,7 +2402,7 @@
           {
             "rule": {
               "index": 1,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -2419,7 +2419,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2436,7 +2436,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2453,7 +2453,7 @@
           {
             "rule": {
               "index": 4,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2470,7 +2470,7 @@
           {
             "rule": {
               "index": 5,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -2553,7 +2553,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -2570,7 +2570,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -2587,7 +2587,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -2604,7 +2604,7 @@
       {
         "rule": {
           "index": 4,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -2621,7 +2621,7 @@
       {
         "rule": {
           "index": 5,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -2699,7 +2699,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -2716,7 +2716,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -2733,7 +2733,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -2802,7 +2802,7 @@
           {
             "rule": {
               "index": 1,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -2819,7 +2819,7 @@
           {
             "rule": {
               "index": 2,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2836,7 +2836,7 @@
           {
             "rule": {
               "index": 3,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2853,7 +2853,7 @@
           {
             "rule": {
               "index": 4,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": false,
             "result": {
@@ -2870,7 +2870,7 @@
           {
             "rule": {
               "index": 5,
-              "annotation": "\"\""
+              "annotation": ""
             },
             "matched": true,
             "result": {
@@ -2953,7 +2953,7 @@
       {
         "rule": {
           "index": 1,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {
@@ -2970,7 +2970,7 @@
       {
         "rule": {
           "index": 2,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -2987,7 +2987,7 @@
       {
         "rule": {
           "index": 3,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -3004,7 +3004,7 @@
       {
         "rule": {
           "index": 4,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": false,
         "result": {
@@ -3021,7 +3021,7 @@
       {
         "rule": {
           "index": 5,
-          "annotation": "\"\""
+          "annotation": ""
         },
         "matched": true,
         "result": {

--- a/dmn-signavio-it/dmn-signavio-it-translator/src/test/resources/traces/example_credit_decision/50-25-tree.json
+++ b/dmn-signavio-it/dmn-signavio-it-translator/src/test/resources/traces/example_credit_decision/50-25-tree.json
@@ -77,7 +77,7 @@
         {
           "rule": {
             "index": 2,
-            "annotation": "\"\""
+            "annotation": ""
           },
           "matched": false,
           "result": {
@@ -94,7 +94,7 @@
         {
           "rule": {
             "index": 3,
-            "annotation": "\"\""
+            "annotation": ""
           },
           "matched": true,
           "result": {
@@ -137,7 +137,7 @@
             {
               "rule": {
                 "index": 3,
-                "annotation": "\"\""
+                "annotation": ""
               },
               "matched": true,
               "result": {
@@ -226,7 +226,7 @@
                     {
                       "rule": {
                         "index": 1,
-                        "annotation": "\"\""
+                        "annotation": ""
                       },
                       "matched": true,
                       "result": {
@@ -243,7 +243,7 @@
                     {
                       "rule": {
                         "index": 2,
-                        "annotation": "\"\""
+                        "annotation": ""
                       },
                       "matched": false,
                       "result": {
@@ -260,7 +260,7 @@
                     {
                       "rule": {
                         "index": 3,
-                        "annotation": "\"\""
+                        "annotation": ""
                       },
                       "matched": false,
                       "result": {
@@ -277,7 +277,7 @@
                     {
                       "rule": {
                         "index": 4,
-                        "annotation": "\"\""
+                        "annotation": ""
                       },
                       "matched": false,
                       "result": {
@@ -294,7 +294,7 @@
                     {
                       "rule": {
                         "index": 5,
-                        "annotation": "\"\""
+                        "annotation": ""
                       },
                       "matched": true,
                       "result": {
@@ -374,7 +374,7 @@
                 {
                   "rule": {
                     "index": 1,
-                    "annotation": "\"\""
+                    "annotation": ""
                   },
                   "matched": false,
                   "result": {
@@ -391,7 +391,7 @@
                 {
                   "rule": {
                     "index": 2,
-                    "annotation": "\"\""
+                    "annotation": ""
                   },
                   "matched": false,
                   "result": {
@@ -408,7 +408,7 @@
                 {
                   "rule": {
                     "index": 3,
-                    "annotation": "\"\""
+                    "annotation": ""
                   },
                   "matched": true,
                   "result": {
@@ -456,7 +456,7 @@
         {
           "rule": {
             "index": 3,
-            "annotation": "\"\""
+            "annotation": ""
           },
           "matched": true,
           "result": {
@@ -541,7 +541,7 @@
                 {
                   "rule": {
                     "index": 1,
-                    "annotation": "\"\""
+                    "annotation": ""
                   },
                   "matched": true,
                   "result": {
@@ -558,7 +558,7 @@
                 {
                   "rule": {
                     "index": 2,
-                    "annotation": "\"\""
+                    "annotation": ""
                   },
                   "matched": false,
                   "result": {
@@ -575,7 +575,7 @@
                 {
                   "rule": {
                     "index": 3,
-                    "annotation": "\"\""
+                    "annotation": ""
                   },
                   "matched": false,
                   "result": {
@@ -592,7 +592,7 @@
                 {
                   "rule": {
                     "index": 4,
-                    "annotation": "\"\""
+                    "annotation": ""
                   },
                   "matched": false,
                   "result": {
@@ -609,7 +609,7 @@
                 {
                   "rule": {
                     "index": 5,
-                    "annotation": "\"\""
+                    "annotation": ""
                   },
                   "matched": true,
                   "result": {
@@ -689,7 +689,7 @@
             {
               "rule": {
                 "index": 1,
-                "annotation": "\"\""
+                "annotation": ""
               },
               "matched": false,
               "result": {
@@ -706,7 +706,7 @@
             {
               "rule": {
                 "index": 2,
-                "annotation": "\"\""
+                "annotation": ""
               },
               "matched": false,
               "result": {
@@ -723,7 +723,7 @@
             {
               "rule": {
                 "index": 3,
-                "annotation": "\"\""
+                "annotation": ""
               },
               "matched": true,
               "result": {
@@ -794,7 +794,7 @@
             {
               "rule": {
                 "index": 1,
-                "annotation": "\"\""
+                "annotation": ""
               },
               "matched": true,
               "result": {
@@ -811,7 +811,7 @@
             {
               "rule": {
                 "index": 2,
-                "annotation": "\"\""
+                "annotation": ""
               },
               "matched": false,
               "result": {
@@ -828,7 +828,7 @@
             {
               "rule": {
                 "index": 3,
-                "annotation": "\"\""
+                "annotation": ""
               },
               "matched": false,
               "result": {
@@ -845,7 +845,7 @@
             {
               "rule": {
                 "index": 4,
-                "annotation": "\"\""
+                "annotation": ""
               },
               "matched": false,
               "result": {
@@ -862,7 +862,7 @@
             {
               "rule": {
                 "index": 5,
-                "annotation": "\"\""
+                "annotation": ""
               },
               "matched": true,
               "result": {

--- a/dmn-signavio/src/main/resources/templates/testlab/java/common/junit.ftl
+++ b/dmn-signavio/src/main/resources/templates/testlab/java/common/junit.ftl
@@ -37,7 +37,7 @@ public class ${testClassName} extends ${decisionBaseClass} {
 <#macro addTestCases>
     <#list testLab.testCases>
         <#items as testCase>
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase${(testCase?index + 1)?c}() {
         ${testLabUtil.executionContextClassName()} ${testLabUtil.executionContextVariableName()} = ${testLabUtil.defaultConstructor(testLabUtil.executionContextClassName())};
         <@addApplyPart testCase/>

--- a/dmn-signavio/src/main/resources/templates/testlab/kotlin/common/junit.ftl
+++ b/dmn-signavio/src/main/resources/templates/testlab/kotlin/common/junit.ftl
@@ -31,7 +31,7 @@ class ${testClassName} : ${decisionBaseClass}() {
 <#macro addTestCases>
     <#list testLab.testCases>
         <#items as testCase>
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase${(testCase?index + 1)?c}() {
         val ${testLabUtil.executionContextVariableName()} = ${testLabUtil.executionContextClassName()}()
         <@addApplyPart testCase/>

--- a/dmn-signavio/src/test/java/com/gs/dmn/signavio/transformation/InOutCorrectPathsInDecisionsTransformerTest.java
+++ b/dmn-signavio/src/test/java/com/gs/dmn/signavio/transformation/InOutCorrectPathsInDecisionsTransformerTest.java
@@ -24,7 +24,7 @@ import com.gs.dmn.signavio.SignavioDMNModelRepository;
 import com.gs.dmn.signavio.testlab.TestLab;
 import com.gs.dmn.signavio.transformation.config.Correction;
 import com.gs.dmn.signavio.transformation.config.DecisionTableCorrection;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,7 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class InOutCorrectPathsInDecisionsTransformerTest extends AbstractSignavioFileTransformerTest {
     private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/dmn-tck-it/dmn-tck-it-translator/src/test/java/com/gs/dmn/generated/other/decision_table_with_annotations/HandWrittenDecisionTableWithAnnotationsTest.java
+++ b/dmn-tck-it/dmn-tck-it-translator/src/test/java/com/gs/dmn/generated/other/decision_table_with_annotations/HandWrittenDecisionTableWithAnnotationsTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @javax.annotation.Generated(value = {"junit.ftl", "decision-table-with-annotations.dmn"})
 public class HandWrittenDecisionTableWithAnnotationsTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -25,7 +25,7 @@ public class HandWrittenDecisionTableWithAnnotationsTest extends com.gs.dmn.runt
         assertEquals(expectedAnnotations, actualAnnotations);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase002() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/bkmfrombkm/DecisionTest.java
+++ b/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/bkmfrombkm/DecisionTest.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 public class DecisionTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision {
     private final Decision decision = new Decision();
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         javax.xml.datatype.XMLGregorianCalendar t = time("12:00:00+01:00");

--- a/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/bkmwithliteralexpression/DecisionLitexpTest.java
+++ b/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/bkmwithliteralexpression/DecisionLitexpTest.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 public class DecisionLitexpTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision {
     private final DecisionLitexp decisionLitexp = new DecisionLitexp();
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         List<java.math.BigDecimal> numz = asList(number("1"), number("43"));

--- a/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/comparelists/ProcessL1Test.java
+++ b/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/comparelists/ProcessL1Test.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 public class ProcessL1Test extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision {
     private final ProcessL1 processL1 = new ProcessL1();
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         List<java.math.BigDecimal> l1 = asList(number("1"), number("2"), number("3"), number("4"));
@@ -16,7 +16,7 @@ public class ProcessL1Test extends com.gs.dmn.signavio.runtime.DefaultSignavioBa
         checkValues(asList(number("2"), number("1"), number("1"), number("0")), processL1);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase2() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         List<java.math.BigDecimal> l1 = asList(number("10"), number("20"), number("30"));
@@ -26,7 +26,7 @@ public class ProcessL1Test extends com.gs.dmn.signavio.runtime.DefaultSignavioBa
         checkValues(asList(number("1"), number("1"), number("0")), processL1);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase3() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         List<java.math.BigDecimal> l1 = asList(numericUnaryMinus(number("1")), number("0"), number("1"));

--- a/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/complex-mid/BigMidTest.java
+++ b/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/complex-mid/BigMidTest.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 public class BigMidTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision {
     private final BigMid bigMid = new BigMid();
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         type.TestPeopleType testPeopleType = new type.TestPeopleTypeImpl(asList(new type.TestPersonTypeImpl(number("23"), "a", asList("Sad", "Quiet"))));
@@ -15,7 +15,7 @@ public class BigMidTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseD
         checkValues(asList(Boolean.TRUE), bigMid);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase2() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         type.TestPeopleType testPeopleType = new type.TestPeopleTypeImpl(asList(new type.TestPersonTypeImpl(number("43"), "g", asList("Happy", "Tall")), new type.TestPersonTypeImpl(number("5"), "l", asList("Short", "Loud", "Happy"))));

--- a/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/example-credit-decision/GenerateOutputDataTest.java
+++ b/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/example-credit-decision/GenerateOutputDataTest.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 public class GenerateOutputDataTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision {
     private final GenerateOutputData generateOutputData = new GenerateOutputData();
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         java.math.BigDecimal currentRiskAppetite = number("50");
@@ -17,7 +17,7 @@ public class GenerateOutputDataTest extends com.gs.dmn.signavio.runtime.DefaultS
         checkValues(asList(new type.GenerateOutputDataImpl(number("27.5"), "Accept", numericUnaryMinus(number("7.5")))), generateOutputData);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase2() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         java.math.BigDecimal currentRiskAppetite = number("50");
@@ -28,7 +28,7 @@ public class GenerateOutputDataTest extends com.gs.dmn.signavio.runtime.DefaultS
         checkValues(asList(new type.GenerateOutputDataImpl(numericUnaryMinus(number("10")), "Reject", numericUnaryMinus(number("25")))), generateOutputData);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase3() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         java.math.BigDecimal currentRiskAppetite = number("50");

--- a/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/executionanalysistestmodel/OutputExecutionAnalysisResultTest.java
+++ b/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/executionanalysistestmodel/OutputExecutionAnalysisResultTest.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 public class OutputExecutionAnalysisResultTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision {
     private final OutputExecutionAnalysisResult outputExecutionAnalysisResult = new OutputExecutionAnalysisResult();
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         java.math.BigDecimal inputValue = number("0");
@@ -15,7 +15,7 @@ public class OutputExecutionAnalysisResultTest extends com.gs.dmn.signavio.runti
         checkValues(asList(), outputExecutionAnalysisResult);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase2() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         java.math.BigDecimal inputValue = number("2");
@@ -24,7 +24,7 @@ public class OutputExecutionAnalysisResultTest extends com.gs.dmn.signavio.runti
         checkValues(asList("Output1", "Output2"), outputExecutionAnalysisResult);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase3() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         java.math.BigDecimal inputValue = number("5");
@@ -33,7 +33,7 @@ public class OutputExecutionAnalysisResultTest extends com.gs.dmn.signavio.runti
         checkValues(asList("Output1", "Output2", "Output3", "Output4", "Output5"), outputExecutionAnalysisResult);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase4() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         java.math.BigDecimal inputValue = number("8");
@@ -42,7 +42,7 @@ public class OutputExecutionAnalysisResultTest extends com.gs.dmn.signavio.runti
         checkValues(asList("Output1", "Output2", "Output3", "Output4", "Output5", "Output6", "Output7", "Output8"), outputExecutionAnalysisResult);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase5() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         java.math.BigDecimal inputValue = number("10");

--- a/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/multi-list-output-top-decision/CompileTest.java
+++ b/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/multi-list-output-top-decision/CompileTest.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 public class CompileTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision {
     private final Compile compile = new Compile();
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         List<java.math.BigDecimal> numbers = asList(number("1"), number("2"));

--- a/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/npevalidation2/ZipTest.java
+++ b/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/npevalidation2/ZipTest.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 public class ZipTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision {
     private final Zip zip = new Zip();
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         java.math.BigDecimal day = number("25");
@@ -22,7 +22,7 @@ public class ZipTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDeci
         checkValues(asList(new type.ZipImpl(number("25"), "not exactly 1 to 5", number("0"), number("0"), "Fred", number("12")), new type.ZipImpl(number("40"), "non of the numbers 1 to 5", number("0"), number("0"), "Jim", number("2016")), new type.ZipImpl(number("65"), null, number("0"), number("0"), "Tom", number("7")), new type.ZipImpl(number("80"), null, numericUnaryMinus(number("359")), numericUnaryMinus(number("8612")), "Sarah", number("25")), new type.ZipImpl(number("105"), null, null, null, "Kate", number("5"))), zip);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase2() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         java.math.BigDecimal day = number("1");

--- a/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/null-safe-tests/AllTogetherTest.java
+++ b/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/null-safe-tests/AllTogetherTest.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 public class AllTogetherTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision {
     private final AllTogether allTogether = new AllTogether();
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         Boolean booleanA = Boolean.TRUE;
@@ -25,7 +25,7 @@ public class AllTogetherTest extends com.gs.dmn.signavio.runtime.DefaultSignavio
         checkValues("NotNull", allTogether);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase2() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         Boolean booleanA = Boolean.TRUE;
@@ -44,7 +44,7 @@ public class AllTogetherTest extends com.gs.dmn.signavio.runtime.DefaultSignavio
         checkValues(null, allTogether);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase3() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         Boolean booleanA = Boolean.FALSE;
@@ -63,7 +63,7 @@ public class AllTogetherTest extends com.gs.dmn.signavio.runtime.DefaultSignavio
         checkValues(null, allTogether);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase4() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         Boolean booleanA = Boolean.FALSE;
@@ -82,7 +82,7 @@ public class AllTogetherTest extends com.gs.dmn.signavio.runtime.DefaultSignavio
         checkValues("NotNull", allTogether);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase5() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         Boolean booleanA = Boolean.FALSE;
@@ -101,7 +101,7 @@ public class AllTogetherTest extends com.gs.dmn.signavio.runtime.DefaultSignavio
         checkValues("NotNull", allTogether);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase6() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         Boolean booleanA = Boolean.TRUE;

--- a/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/nulls-with-zip-function/MidTest.java
+++ b/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/nulls-with-zip-function/MidTest.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 public class MidTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision {
     private final Mid mid = new Mid();
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         List<java.math.BigDecimal> inputB = asList(number("34"), number("3"));
@@ -16,7 +16,7 @@ public class MidTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDeci
         checkValues(asList("both defined", "number defined"), mid);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase2() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         List<java.math.BigDecimal> inputB = asList(number("12"));
@@ -26,7 +26,7 @@ public class MidTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDeci
         checkValues(asList("both defined", "text defined"), mid);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase3() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         List<java.math.BigDecimal> inputB = asList(number("213"), null, number("43"));
@@ -36,7 +36,7 @@ public class MidTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDeci
         checkValues(asList("both defined", "text defined", "both defined"), mid);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase4() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         List<java.math.BigDecimal> inputB = asList(null);

--- a/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/simple-mid-legacy/MidTest.java
+++ b/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/simple-mid-legacy/MidTest.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 public class MidTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision {
     private final Mid mid = new Mid();
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         List<java.math.BigDecimal> numz = asList(number("1"), number("2"));
@@ -15,7 +15,7 @@ public class MidTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDeci
         checkValues(asList("child", "child"), mid);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase2() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         List<java.math.BigDecimal> numz = asList(number("50"), number("100"));

--- a/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/simple-mid/MidTest.java
+++ b/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/simple-mid/MidTest.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 public class MidTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision {
     private final Mid mid = new Mid();
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         List<java.math.BigDecimal> numz = asList(number("1"), number("2"));
@@ -15,7 +15,7 @@ public class MidTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDeci
         checkValues(asList("child", "child"), mid);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase2() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         List<java.math.BigDecimal> numz = asList(number("50"), number("100"));

--- a/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/simple-model/FruitColourTest.java
+++ b/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/simple-model/FruitColourTest.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 public class FruitColourTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision {
     private final FruitColour fruitColour = new FruitColour();
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         String fruits = "Apples";
@@ -15,7 +15,7 @@ public class FruitColourTest extends com.gs.dmn.signavio.runtime.DefaultSignavio
         checkValues("Red", fruitColour);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase2() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         String fruits = "Bananas";
@@ -24,7 +24,7 @@ public class FruitColourTest extends com.gs.dmn.signavio.runtime.DefaultSignavio
         checkValues("Yellow", fruitColour);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase3() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         String fruits = "Grapes";

--- a/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/testdecision/TestTest.java
+++ b/dmn-test-cases/signavio/dmn/dmn2java/expected/complex/test-lab/testdecision/TestTest.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 public class TestTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision {
     private final Test test = new Test();
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         String stringInput = "a";
@@ -15,7 +15,7 @@ public class TestTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDec
         checkValues(asList("a", "b"), test);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase2() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         String stringInput = "c";

--- a/dmn-test-cases/signavio/dmn/dmn2java/expected/proto/proto3/java/test-lab/date-time-proto/DateTest.java
+++ b/dmn-test-cases/signavio/dmn/dmn2java/expected/proto/proto3/java/test-lab/date-time-proto/DateTest.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 public class DateTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision {
     private final Date date = new Date();
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         javax.xml.datatype.XMLGregorianCalendar inputDate = date("2020-09-21");

--- a/dmn-test-cases/signavio/dmn/dmn2java/expected/proto/proto3/java/test-lab/example-credit-decision/GenerateOutputDataTest.java
+++ b/dmn-test-cases/signavio/dmn/dmn2java/expected/proto/proto3/java/test-lab/example-credit-decision/GenerateOutputDataTest.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 public class GenerateOutputDataTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision {
     private final GenerateOutputData generateOutputData = new GenerateOutputData();
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         java.math.BigDecimal currentRiskAppetite = number("50");
@@ -36,7 +36,7 @@ public class GenerateOutputDataTest extends com.gs.dmn.signavio.runtime.DefaultS
         checkValues(((List) (asList(new type.GenerateOutputDataImpl(number("27.5"), "Accept", numericUnaryMinus(number("7.5")))) == null ? null : asList(new type.GenerateOutputDataImpl(number("27.5"), "Accept", numericUnaryMinus(number("7.5")))).stream().map(type.GenerateOutputData::toProto).collect(java.util.stream.Collectors.toList()))), generateOutputDataProto_);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase2() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         java.math.BigDecimal currentRiskAppetite = number("50");
@@ -66,7 +66,7 @@ public class GenerateOutputDataTest extends com.gs.dmn.signavio.runtime.DefaultS
         checkValues(((List) (asList(new type.GenerateOutputDataImpl(numericUnaryMinus(number("10")), "Reject", numericUnaryMinus(number("25")))) == null ? null : asList(new type.GenerateOutputDataImpl(numericUnaryMinus(number("10")), "Reject", numericUnaryMinus(number("25")))).stream().map(type.GenerateOutputData::toProto).collect(java.util.stream.Collectors.toList()))), generateOutputDataProto_);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase3() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         java.math.BigDecimal currentRiskAppetite = number("50");

--- a/dmn-test-cases/signavio/dmn/dmn2java/expected/proto/proto3/kotlin/test-lab/date-time-proto/DateTest.kt
+++ b/dmn-test-cases/signavio/dmn/dmn2java/expected/proto/proto3/kotlin/test-lab/date-time-proto/DateTest.kt
@@ -6,7 +6,7 @@ import java.util.stream.Collectors
 class DateTest : com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision() {
     private val date = Date()
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase1() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val inputDate: javax.xml.datatype.XMLGregorianCalendar? = date("2020-09-21")

--- a/dmn-test-cases/signavio/dmn/dmn2java/expected/proto/proto3/kotlin/test-lab/example-credit-decision/GenerateOutputDataTest.kt
+++ b/dmn-test-cases/signavio/dmn/dmn2java/expected/proto/proto3/kotlin/test-lab/example-credit-decision/GenerateOutputDataTest.kt
@@ -6,7 +6,7 @@ import java.util.stream.Collectors
 class GenerateOutputDataTest : com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision() {
     private val generateOutputData = GenerateOutputData()
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase1() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val currentRiskAppetite: java.math.BigDecimal? = number("50")
@@ -36,7 +36,7 @@ class GenerateOutputDataTest : com.gs.dmn.signavio.runtime.DefaultSignavioBaseDe
         checkValues(asList(type.GenerateOutputDataImpl(number("27.5"), "Accept", numericUnaryMinus(number("7.5"))))?.stream()?.map({e -> type.GenerateOutputData.toProto(e)})?.collect(java.util.stream.Collectors.toList()), generateOutputDataProto_)
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase2() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val currentRiskAppetite: java.math.BigDecimal? = number("50")
@@ -66,7 +66,7 @@ class GenerateOutputDataTest : com.gs.dmn.signavio.runtime.DefaultSignavioBaseDe
         checkValues(asList(type.GenerateOutputDataImpl(numericUnaryMinus(number("10")), "Reject", numericUnaryMinus(number("25"))))?.stream()?.map({e -> type.GenerateOutputData.toProto(e)})?.collect(java.util.stream.Collectors.toList()), generateOutputDataProto_)
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase3() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val currentRiskAppetite: java.math.BigDecimal? = number("50")

--- a/dmn-test-cases/signavio/dmn/dmn2java/expected/singleton/java/test-lab/example-credit-decision/GenerateOutputDataTest.java
+++ b/dmn-test-cases/signavio/dmn/dmn2java/expected/singleton/java/test-lab/example-credit-decision/GenerateOutputDataTest.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 public class GenerateOutputDataTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision {
     private final GenerateOutputData generateOutputData = GenerateOutputData.instance();
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         java.math.BigDecimal currentRiskAppetite = number("50");
@@ -17,7 +17,7 @@ public class GenerateOutputDataTest extends com.gs.dmn.signavio.runtime.DefaultS
         checkValues(asList(new type.GenerateOutputDataImpl(number("27.5"), "Accept", numericUnaryMinus(number("7.5")))), generateOutputData);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase2() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         java.math.BigDecimal currentRiskAppetite = number("50");
@@ -28,7 +28,7 @@ public class GenerateOutputDataTest extends com.gs.dmn.signavio.runtime.DefaultS
         checkValues(asList(new type.GenerateOutputDataImpl(numericUnaryMinus(number("10")), "Reject", numericUnaryMinus(number("25")))), generateOutputData);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase3() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         java.math.BigDecimal currentRiskAppetite = number("50");

--- a/dmn-test-cases/signavio/rdf/rdf2java/expected/java/decision-table/test-lab/compound-decision-primitive-type-inputs-sfeel-input-entries-compound-output-first-hit-policy/CompoundOutputCompoundDecisionTest.java
+++ b/dmn-test-cases/signavio/rdf/rdf2java/expected/java/decision-table/test-lab/compound-decision-primitive-type-inputs-sfeel-input-entries-compound-output-first-hit-policy/CompoundOutputCompoundDecisionTest.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 public class CompoundOutputCompoundDecisionTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision {
     private final CompoundOutputCompoundDecision compoundOutputCompoundDecision = new CompoundOutputCompoundDecision();
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         java.math.BigDecimal dD2NumberInput = number("1");

--- a/dmn-test-cases/signavio/rdf/rdf2java/expected/java/decision-table/test-lab/simple-decision-complex-type-inputs-sfeel-input-entries-single-output-collect-hit-policy/DecisionTest.java
+++ b/dmn-test-cases/signavio/rdf/rdf2java/expected/java/decision-table/test-lab/simple-decision-complex-type-inputs-sfeel-input-entries-single-output-collect-hit-policy/DecisionTest.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 public class DecisionTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision {
     private final Decision decision = new Decision();
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         Boolean employed = null;
@@ -16,7 +16,7 @@ public class DecisionTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBas
         checkValues(asList(), decision);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase2() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         Boolean employed = Boolean.TRUE;
@@ -26,7 +26,7 @@ public class DecisionTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBas
         checkValues(asList(), decision);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase3() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         Boolean employed = Boolean.TRUE;

--- a/dmn-test-cases/signavio/rdf/rdf2java/expected/java/decision-table/test-lab/simple-decision-primitive-type-inputs-feel-input-entries-single-output-first-hit-policy/DecisionTest.java
+++ b/dmn-test-cases/signavio/rdf/rdf2java/expected/java/decision-table/test-lab/simple-decision-primitive-type-inputs-feel-input-entries-single-output-first-hit-policy/DecisionTest.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 public class DecisionTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBaseDecision {
     private final Decision decision = new Decision();
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         javax.xml.datatype.XMLGregorianCalendar timeInput = null;
@@ -21,7 +21,7 @@ public class DecisionTest extends com.gs.dmn.signavio.runtime.DefaultSignavioBas
         checkValues("r7", decision);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase2() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         javax.xml.datatype.XMLGregorianCalendar timeInput = null;

--- a/dmn-test-cases/standard/composite/1.2/0001-no-name-conflicts-one-package/translator/expected/java/test/ModelB1Test.java
+++ b/dmn-test-cases/standard/composite/1.2/0001-no-name-conflicts-one-package/translator/expected/java/test/ModelB1Test.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "Model B1"})
 public class ModelB1Test extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/composite/1.2/0001-no-name-conflicts-one-package/translator/expected/java/test/ModelCTest.java
+++ b/dmn-test-cases/standard/composite/1.2/0001-no-name-conflicts-one-package/translator/expected/java/test/ModelCTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "Model C"})
 public class ModelCTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/composite/1.2/0002-no-name-conflicts/translator/expected/java/test/model_b1/ModelB1Test.java
+++ b/dmn-test-cases/standard/composite/1.2/0002-no-name-conflicts/translator/expected/java/test/model_b1/ModelB1Test.java
@@ -5,7 +5,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "Model B1"})
 public class ModelB1Test extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/composite/1.2/0002-no-name-conflicts/translator/expected/java/test/model_c/ModelCTest.java
+++ b/dmn-test-cases/standard/composite/1.2/0002-no-name-conflicts/translator/expected/java/test/model_c/ModelCTest.java
@@ -5,7 +5,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "Model C"})
 public class ModelCTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/composite/1.2/0003-name-conflicts/translator/expected/java/test/model_b1/ModelB1Test.java
+++ b/dmn-test-cases/standard/composite/1.2/0003-name-conflicts/translator/expected/java/test/model_b1/ModelB1Test.java
@@ -5,7 +5,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "Model B1"})
 public class ModelB1Test extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/composite/1.2/0003-name-conflicts/translator/expected/java/test/model_c/ModelCTest.java
+++ b/dmn-test-cases/standard/composite/1.2/0003-name-conflicts/translator/expected/java/test/model_c/ModelCTest.java
@@ -5,7 +5,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "Model C"})
 public class ModelCTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/composite/1.2/0004-decision-tables/translator/expected/java/test/decisiontables/DecisionTablesTest.java
+++ b/dmn-test-cases/standard/composite/1.2/0004-decision-tables/translator/expected/java/test/decisiontables/DecisionTablesTest.java
@@ -5,7 +5,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "decisionTables"})
 public class DecisionTablesTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -16,7 +16,7 @@ public class DecisionTablesTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisio
         checkValues(Boolean.TRUE, new decisiontables.PriceGt10().apply(decisioninputs_structA, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase002() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -29,7 +29,7 @@ public class DecisionTablesTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisio
         checkValues("Not in range", new decisiontables.PriceInRange().apply(decisioninputs_numB, decisioninputs_numC, decisioninputs_structA, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase003() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -40,7 +40,7 @@ public class DecisionTablesTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisio
         checkValues(Boolean.TRUE, new decisiontables.DateCompare1().apply(decisioninputs_dateD, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase004() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/composite/1.2/0005-decision-tables-name-conflicts/translator/expected/java/test/decisiontables/DecisionTablesTest.java
+++ b/dmn-test-cases/standard/composite/1.2/0005-decision-tables-name-conflicts/translator/expected/java/test/decisiontables/DecisionTablesTest.java
@@ -5,7 +5,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "decisionTables"})
 public class DecisionTablesTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -16,7 +16,7 @@ public class DecisionTablesTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisio
         checkValues(Boolean.TRUE, new decisiontables.PriceGt10().apply(decisioninputs1_structA, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase002() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -29,7 +29,7 @@ public class DecisionTablesTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisio
         checkValues("Not in range", new decisiontables.PriceInRange().apply(decisioninputs1_numB, decisioninputs1_numC, decisioninputs1_structA, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase003() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -40,7 +40,7 @@ public class DecisionTablesTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisio
         checkValues(Boolean.TRUE, new decisiontables.DateCompare1().apply(decisioninputs1_dateD, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase004() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/composite/1.2/0006-multiple-input-data/translator/expected/java/test/nested_input_data_imports/NestedInputDataImportsTest.java
+++ b/dmn-test-cases/standard/composite/1.2/0006-multiple-input-data/translator/expected/java/test/nested_input_data_imports/NestedInputDataImportsTest.java
@@ -5,7 +5,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "Nested Input Data Imports"})
 public class NestedInputDataImportsTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/composite/1.2/0007-name-conflicts-same-decision-singleton/translator/expected/java/test/model_c/ModelCTest.java
+++ b/dmn-test-cases/standard/composite/1.2/0007-name-conflicts-same-decision-singleton/translator/expected/java/test/model_c/ModelCTest.java
@@ -5,7 +5,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "Model C"})
 public class ModelCTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/composite/1.2/0008-name-conflicts-same-decision-no-singleton/translator/expected/java/test/model_c/ModelCTest.java
+++ b/dmn-test-cases/standard/composite/1.2/0008-name-conflicts-same-decision-no-singleton/translator/expected/java/test/model_c/ModelCTest.java
@@ -5,7 +5,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "Model C"})
 public class ModelCTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/composite/1.2/0009-type-name-conflicts/translator/expected/java/test/ModelCTest.java
+++ b/dmn-test-cases/standard/composite/1.2/0009-type-name-conflicts/translator/expected/java/test/ModelCTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "Model C"})
 public class ModelCTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/composite/1.2/0010-bkm-name-conflicts/translator/expected/java/test/model_c/ModelCTest.java
+++ b/dmn-test-cases/standard/composite/1.2/0010-bkm-name-conflicts/translator/expected/java/test/model_c/ModelCTest.java
@@ -5,7 +5,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "Model C"})
 public class ModelCTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/proto/1.1/0004-lending/translator/expected/proto3/java/test/_0004LendingTest.java
+++ b/dmn-test-cases/standard/proto/1.1/0004-lending/translator/expected/proto3/java/test/_0004LendingTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0004-lending.dmn"})
 public class _0004LendingTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/proto/1.1/0004-lending/translator/expected/proto3/kotlin/test/_0004LendingTest.kt
+++ b/dmn-test-cases/standard/proto/1.1/0004-lending/translator/expected/proto3/kotlin/test/_0004LendingTest.kt
@@ -4,7 +4,7 @@ import java.util.stream.Collectors
 
 @javax.annotation.Generated(value = ["junit.ftl", "0004-lending.dmn"])
 class _0004LendingTest : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase001() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()

--- a/dmn-test-cases/standard/proto/1.1/date-time-proto/translator/expected/proto3/java/test/DateTimeProtoTest.java
+++ b/dmn-test-cases/standard/proto/1.1/date-time-proto/translator/expected/proto3/java/test/DateTimeProtoTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "date-time-proto.dmn"})
 public class DateTimeProtoTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase1() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -22,7 +22,7 @@ public class DateTimeProtoTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision
         checkValues(string(date("2020-09-10")), new Date().applyProto(dateRequest_, context_).getDate());
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase2() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -40,7 +40,7 @@ public class DateTimeProtoTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision
         checkValues(string(time("12:10:10")), new Time().applyProto(timeRequest_, context_).getTime());
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase3() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -58,7 +58,7 @@ public class DateTimeProtoTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision
         checkValues(string(dateAndTime("2020-09-19T12:10:10")), new DateTime().applyProto(dateTimeRequest_, context_).getDateTime());
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase4() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/proto/1.1/date-time-proto/translator/expected/proto3/kotlin/test/DateTimeProtoTest.kt
+++ b/dmn-test-cases/standard/proto/1.1/date-time-proto/translator/expected/proto3/kotlin/test/DateTimeProtoTest.kt
@@ -4,7 +4,7 @@ import java.util.stream.Collectors
 
 @javax.annotation.Generated(value = ["junit.ftl", "date-time-proto.dmn"])
 class DateTimeProtoTest : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase1() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()
@@ -22,7 +22,7 @@ class DateTimeProtoTest : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
         checkValues(string(date("2020-09-10")), Date().applyProto(dateRequest_, context_).getDate())
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase2() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()
@@ -40,7 +40,7 @@ class DateTimeProtoTest : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
         checkValues(string(time("12:10:10")), Time().applyProto(timeRequest_, context_).getTime())
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase3() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()
@@ -58,7 +58,7 @@ class DateTimeProtoTest : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
         checkValues(string(dateAndTime("2020-09-19T12:10:10")), DateTime().applyProto(dateTimeRequest_, context_).getDateTime())
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase4() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()

--- a/dmn-test-cases/standard/tck/1.1/cl2/0004-simpletable-U/translator/expected/java/test/_0004SimpletableUTest.java
+++ b/dmn-test-cases/standard/tck/1.1/cl2/0004-simpletable-U/translator/expected/java/test/_0004SimpletableUTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0004-simpletable-U.dmn"})
 public class _0004SimpletableUTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -17,7 +17,7 @@ public class _0004SimpletableUTest extends com.gs.dmn.runtime.DefaultDMNBaseDeci
         checkValues("Approved", new ApprovalStatus().apply(age, riskCategory, isAffordable, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase002() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -30,7 +30,7 @@ public class _0004SimpletableUTest extends com.gs.dmn.runtime.DefaultDMNBaseDeci
         checkValues("Declined", new ApprovalStatus().apply(age, riskCategory, isAffordable, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase003() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.1/cl2/0004-simpletable-U/translator/expected/kotlin/test/_0004SimpletableUTest.kt
+++ b/dmn-test-cases/standard/tck/1.1/cl2/0004-simpletable-U/translator/expected/kotlin/test/_0004SimpletableUTest.kt
@@ -4,7 +4,7 @@ import java.util.stream.Collectors
 
 @javax.annotation.Generated(value = ["junit.ftl", "0004-simpletable-U.dmn"])
 class _0004SimpletableUTest : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase001() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()
@@ -17,7 +17,7 @@ class _0004SimpletableUTest : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
         checkValues("Approved", ApprovalStatus().apply(age, riskCategory, isAffordable, context_))
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase002() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()
@@ -30,7 +30,7 @@ class _0004SimpletableUTest : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
         checkValues("Declined", ApprovalStatus().apply(age, riskCategory, isAffordable, context_))
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase003() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()

--- a/dmn-test-cases/standard/tck/1.1/cl2/0005-simpletable-A/translator/expected/java/test/_0005SimpletableATest.java
+++ b/dmn-test-cases/standard/tck/1.1/cl2/0005-simpletable-A/translator/expected/java/test/_0005SimpletableATest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0005-simpletable-A.dmn"})
 public class _0005SimpletableATest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -17,7 +17,7 @@ public class _0005SimpletableATest extends com.gs.dmn.runtime.DefaultDMNBaseDeci
         checkValues("Approved", new ApprovalStatus().apply(age, riskCategory, isAffordable, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase002() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -30,7 +30,7 @@ public class _0005SimpletableATest extends com.gs.dmn.runtime.DefaultDMNBaseDeci
         checkValues("Declined", new ApprovalStatus().apply(age, riskCategory, isAffordable, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase003() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.1/cl2/0005-simpletable-A/translator/expected/kotlin/test/_0005SimpletableATest.kt
+++ b/dmn-test-cases/standard/tck/1.1/cl2/0005-simpletable-A/translator/expected/kotlin/test/_0005SimpletableATest.kt
@@ -4,7 +4,7 @@ import java.util.stream.Collectors
 
 @javax.annotation.Generated(value = ["junit.ftl", "0005-simpletable-A.dmn"])
 class _0005SimpletableATest : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase001() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()
@@ -17,7 +17,7 @@ class _0005SimpletableATest : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
         checkValues("Approved", ApprovalStatus().apply(age, riskCategory, isAffordable, context_))
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase002() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()
@@ -30,7 +30,7 @@ class _0005SimpletableATest : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
         checkValues("Declined", ApprovalStatus().apply(age, riskCategory, isAffordable, context_))
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase003() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()

--- a/dmn-test-cases/standard/tck/1.1/cl2/0006-simpletable-P1/translator/expected/java/test/_0006SimpletableP1Test.java
+++ b/dmn-test-cases/standard/tck/1.1/cl2/0006-simpletable-P1/translator/expected/java/test/_0006SimpletableP1Test.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0006-simpletable-P1.dmn"})
 public class _0006SimpletableP1Test extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -17,7 +17,7 @@ public class _0006SimpletableP1Test extends com.gs.dmn.runtime.DefaultDMNBaseDec
         checkValues("Approved", new ApprovalStatus().apply(age, riskCategory, isAffordable, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase002() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -30,7 +30,7 @@ public class _0006SimpletableP1Test extends com.gs.dmn.runtime.DefaultDMNBaseDec
         checkValues("Declined", new ApprovalStatus().apply(age, riskCategory, isAffordable, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase003() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.1/cl2/0006-simpletable-P1/translator/expected/kotlin/test/_0006SimpletableP1Test.kt
+++ b/dmn-test-cases/standard/tck/1.1/cl2/0006-simpletable-P1/translator/expected/kotlin/test/_0006SimpletableP1Test.kt
@@ -4,7 +4,7 @@ import java.util.stream.Collectors
 
 @javax.annotation.Generated(value = ["junit.ftl", "0006-simpletable-P1.dmn"])
 class _0006SimpletableP1Test : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase001() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()
@@ -17,7 +17,7 @@ class _0006SimpletableP1Test : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
         checkValues("Approved", ApprovalStatus().apply(age, riskCategory, isAffordable, context_))
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase002() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()
@@ -30,7 +30,7 @@ class _0006SimpletableP1Test : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
         checkValues("Declined", ApprovalStatus().apply(age, riskCategory, isAffordable, context_))
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase003() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()

--- a/dmn-test-cases/standard/tck/1.1/cl2/0007-simpletable-P2/translator/expected/java/test/_0007SimpletableP2Test.java
+++ b/dmn-test-cases/standard/tck/1.1/cl2/0007-simpletable-P2/translator/expected/java/test/_0007SimpletableP2Test.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0007-simpletable-P2.dmn"})
 public class _0007SimpletableP2Test extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -17,7 +17,7 @@ public class _0007SimpletableP2Test extends com.gs.dmn.runtime.DefaultDMNBaseDec
         checkValues("Approved", new ApprovalStatus().apply(age, riskCategory, isAffordable, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase002() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -30,7 +30,7 @@ public class _0007SimpletableP2Test extends com.gs.dmn.runtime.DefaultDMNBaseDec
         checkValues("Declined", new ApprovalStatus().apply(age, riskCategory, isAffordable, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase003() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.1/cl2/0007-simpletable-P2/translator/expected/kotlin/test/_0007SimpletableP2Test.kt
+++ b/dmn-test-cases/standard/tck/1.1/cl2/0007-simpletable-P2/translator/expected/kotlin/test/_0007SimpletableP2Test.kt
@@ -4,7 +4,7 @@ import java.util.stream.Collectors
 
 @javax.annotation.Generated(value = ["junit.ftl", "0007-simpletable-P2.dmn"])
 class _0007SimpletableP2Test : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase001() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()
@@ -17,7 +17,7 @@ class _0007SimpletableP2Test : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
         checkValues("Approved", ApprovalStatus().apply(age, riskCategory, isAffordable, context_))
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase002() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()
@@ -30,7 +30,7 @@ class _0007SimpletableP2Test : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
         checkValues("Declined", ApprovalStatus().apply(age, riskCategory, isAffordable, context_))
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase003() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()

--- a/dmn-test-cases/standard/tck/1.1/cl2/0008-LX-arithmetic/translator/expected/java/test/_0008LXArithmeticTest.java
+++ b/dmn-test-cases/standard/tck/1.1/cl2/0008-LX-arithmetic/translator/expected/java/test/_0008LXArithmeticTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0008-LX-arithmetic.dmn"})
 public class _0008LXArithmeticTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -15,7 +15,7 @@ public class _0008LXArithmeticTest extends com.gs.dmn.runtime.DefaultDMNBaseDeci
         checkValues(number("2778.69354943277"), new Payment().apply(loan, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase002() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -26,7 +26,7 @@ public class _0008LXArithmeticTest extends com.gs.dmn.runtime.DefaultDMNBaseDeci
         checkValues(number("562.707359373292"), new Payment().apply(loan, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase003() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.1/cl2/0008-LX-arithmetic/translator/expected/kotlin/test/_0008LXArithmeticTest.kt
+++ b/dmn-test-cases/standard/tck/1.1/cl2/0008-LX-arithmetic/translator/expected/kotlin/test/_0008LXArithmeticTest.kt
@@ -4,7 +4,7 @@ import java.util.stream.Collectors
 
 @javax.annotation.Generated(value = ["junit.ftl", "0008-LX-arithmetic.dmn"])
 class _0008LXArithmeticTest : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase001() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()
@@ -15,7 +15,7 @@ class _0008LXArithmeticTest : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
         checkValues(number("2778.69354943277"), Payment().apply(loan, context_))
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase002() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()
@@ -26,7 +26,7 @@ class _0008LXArithmeticTest : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
         checkValues(number("562.707359373292"), Payment().apply(loan, context_))
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase003() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()

--- a/dmn-test-cases/standard/tck/1.1/cl2/0009-invocation-arithmetic/translator/expected/java/test/_0009InvocationArithmeticTest.java
+++ b/dmn-test-cases/standard/tck/1.1/cl2/0009-invocation-arithmetic/translator/expected/java/test/_0009InvocationArithmeticTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0009-invocation-arithmetic.dmn"})
 public class _0009InvocationArithmeticTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -16,7 +16,7 @@ public class _0009InvocationArithmeticTest extends com.gs.dmn.runtime.DefaultDMN
         checkValues(number("2878.69354943277"), new MonthlyPayment().apply(loan, fee, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase002() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -28,7 +28,7 @@ public class _0009InvocationArithmeticTest extends com.gs.dmn.runtime.DefaultDMN
         checkValues(number("662.707359373292"), new MonthlyPayment().apply(loan, fee, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase003() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.1/cl2/0009-invocation-arithmetic/translator/expected/kotlin/test/_0009InvocationArithmeticTest.kt
+++ b/dmn-test-cases/standard/tck/1.1/cl2/0009-invocation-arithmetic/translator/expected/kotlin/test/_0009InvocationArithmeticTest.kt
@@ -4,7 +4,7 @@ import java.util.stream.Collectors
 
 @javax.annotation.Generated(value = ["junit.ftl", "0009-invocation-arithmetic.dmn"])
 class _0009InvocationArithmeticTest : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase001() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()
@@ -16,7 +16,7 @@ class _0009InvocationArithmeticTest : com.gs.dmn.runtime.DefaultDMNBaseDecision(
         checkValues(number("2878.69354943277"), MonthlyPayment().apply(loan, fee, context_))
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase002() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()
@@ -28,7 +28,7 @@ class _0009InvocationArithmeticTest : com.gs.dmn.runtime.DefaultDMNBaseDecision(
         checkValues(number("662.707359373292"), MonthlyPayment().apply(loan, fee, context_))
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase003() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()

--- a/dmn-test-cases/standard/tck/1.1/cl2/0010-multi-output-U/translator/expected/java/test/_0010MultiOutputUTest.java
+++ b/dmn-test-cases/standard/tck/1.1/cl2/0010-multi-output-U/translator/expected/java/test/_0010MultiOutputUTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0010-multi-output-U.dmn"})
 public class _0010MultiOutputUTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -17,7 +17,7 @@ public class _0010MultiOutputUTest extends com.gs.dmn.runtime.DefaultDMNBaseDeci
         checkValues(type.TApproval.toTApproval(new com.gs.dmn.runtime.Context().add("Rate", "Standard").add("Status", "Approved")), new Approval().apply(age, riskCategory, isAffordable, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase002() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -30,7 +30,7 @@ public class _0010MultiOutputUTest extends com.gs.dmn.runtime.DefaultDMNBaseDeci
         checkValues(type.TApproval.toTApproval(new com.gs.dmn.runtime.Context().add("Rate", "Standard").add("Status", "Declined")), new Approval().apply(age, riskCategory, isAffordable, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase003() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.1/cl2/0010-multi-output-U/translator/expected/kotlin/test/_0010MultiOutputUTest.kt
+++ b/dmn-test-cases/standard/tck/1.1/cl2/0010-multi-output-U/translator/expected/kotlin/test/_0010MultiOutputUTest.kt
@@ -4,7 +4,7 @@ import java.util.stream.Collectors
 
 @javax.annotation.Generated(value = ["junit.ftl", "0010-multi-output-U.dmn"])
 class _0010MultiOutputUTest : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase001() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()
@@ -17,7 +17,7 @@ class _0010MultiOutputUTest : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
         checkValues(type.TApproval.toTApproval(com.gs.dmn.runtime.Context().add("Rate", "Standard").add("Status", "Approved")), Approval().apply(age, riskCategory, isAffordable, context_))
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase002() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()
@@ -30,7 +30,7 @@ class _0010MultiOutputUTest : com.gs.dmn.runtime.DefaultDMNBaseDecision() {
         checkValues(type.TApproval.toTApproval(com.gs.dmn.runtime.Context().add("Rate", "Standard").add("Status", "Declined")), Approval().apply(age, riskCategory, isAffordable, context_))
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     fun testCase003() {
         val context_ = com.gs.dmn.runtime.ExecutionContext()
         val cache_ = context_.getCache()

--- a/dmn-test-cases/standard/tck/1.1/cl3/0004-lending/translator/expected/java/test/_0004LendingTest.java
+++ b/dmn-test-cases/standard/tck/1.1/cl3/0004-lending/translator/expected/java/test/_0004LendingTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0004-lending.dmn"})
 public class _0004LendingTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.1/cl3/0005-literal-invocation/translator/expected/java/test/_0005LiteralInvocationTest.java
+++ b/dmn-test-cases/standard/tck/1.1/cl3/0005-literal-invocation/translator/expected/java/test/_0005LiteralInvocationTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0005-literal-invocation.dmn"})
 public class _0005LiteralInvocationTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -16,7 +16,7 @@ public class _0005LiteralInvocationTest extends com.gs.dmn.runtime.DefaultDMNBas
         checkValues(number("2878.69354943277"), new MonthlyPayment().apply(loan, fee, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase002() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -28,7 +28,7 @@ public class _0005LiteralInvocationTest extends com.gs.dmn.runtime.DefaultDMNBas
         checkValues(number("662.707359373292"), new MonthlyPayment().apply(loan, fee, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase003() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.1/cl3/0006-join/translator/expected/java/test/_0006JoinTest.java
+++ b/dmn-test-cases/standard/tck/1.1/cl3/0006-join/translator/expected/java/test/_0006JoinTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0006-join.dmn"})
 public class _0006JoinTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.1/cl3/0013-sort/translator/expected/java/test/_0013SortTest.java
+++ b/dmn-test-cases/standard/tck/1.1/cl3/0013-sort/translator/expected/java/test/_0013SortTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0013-sort.dmn"})
 public class _0013SortTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.1/cl3/0014-loan-comparison/translator/expected/java/test/_0014LoanComparisonTest.java
+++ b/dmn-test-cases/standard/tck/1.1/cl3/0014-loan-comparison/translator/expected/java/test/_0014LoanComparisonTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0014-loan-comparison.dmn"})
 public class _0014LoanComparisonTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.1/cl3/0016-some-every/translator/expected/java/test/_0016SomeEveryTest.java
+++ b/dmn-test-cases/standard/tck/1.1/cl3/0016-some-every/translator/expected/java/test/_0016SomeEveryTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0016-some-every.dmn"})
 public class _0016SomeEveryTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.1/cl3/0017-tableTests/translator/expected/java/test/_0017TableTestsTest.java
+++ b/dmn-test-cases/standard/tck/1.1/cl3/0017-tableTests/translator/expected/java/test/_0017TableTestsTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0017-tableTests.dmn"})
 public class _0017TableTestsTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -15,7 +15,7 @@ public class _0017TableTestsTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisi
         checkValues(Boolean.TRUE, new PriceGt10().apply(structA, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase002() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -28,7 +28,7 @@ public class _0017TableTestsTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisi
         checkValues("Not in range", new PriceInRange().apply(numB, numC, structA, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase003() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -39,7 +39,7 @@ public class _0017TableTestsTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisi
         checkValues(Boolean.TRUE, new DateCompare1().apply(dateD, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase004() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.1/cl3/0020-vacation-days/translator/expected/java/test/_0020VacationDaysTest.java
+++ b/dmn-test-cases/standard/tck/1.1/cl3/0020-vacation-days/translator/expected/java/test/_0020VacationDaysTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0020-vacation-days.dmn"})
 public class _0020VacationDaysTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -16,7 +16,7 @@ public class _0020VacationDaysTest extends com.gs.dmn.runtime.DefaultDMNBaseDeci
         checkValues(number("27"), new TotalVacationDays().apply(age, yearsOfService, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase002() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -28,7 +28,7 @@ public class _0020VacationDaysTest extends com.gs.dmn.runtime.DefaultDMNBaseDeci
         checkValues(number("22"), new TotalVacationDays().apply(age, yearsOfService, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase003() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -40,7 +40,7 @@ public class _0020VacationDaysTest extends com.gs.dmn.runtime.DefaultDMNBaseDeci
         checkValues(number("24"), new TotalVacationDays().apply(age, yearsOfService, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase004() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -52,7 +52,7 @@ public class _0020VacationDaysTest extends com.gs.dmn.runtime.DefaultDMNBaseDeci
         checkValues(number("30"), new TotalVacationDays().apply(age, yearsOfService, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase005() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -64,7 +64,7 @@ public class _0020VacationDaysTest extends com.gs.dmn.runtime.DefaultDMNBaseDeci
         checkValues(number("24"), new TotalVacationDays().apply(age, yearsOfService, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase006() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -76,7 +76,7 @@ public class _0020VacationDaysTest extends com.gs.dmn.runtime.DefaultDMNBaseDeci
         checkValues(number("30"), new TotalVacationDays().apply(age, yearsOfService, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase007() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.1/cl3/0021-singleton-list/translator/expected/java/test/_0021SingletonListTest.java
+++ b/dmn-test-cases/standard/tck/1.1/cl3/0021-singleton-list/translator/expected/java/test/_0021SingletonListTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0021-singleton-list.dmn"})
 public class _0021SingletonListTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.1/cl3/0030-user-defined-functions/translator/expected/java/test/_0030UserDefinedFunctionsTest.java
+++ b/dmn-test-cases/standard/tck/1.1/cl3/0030-user-defined-functions/translator/expected/java/test/_0030UserDefinedFunctionsTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0030-user-defined-functions.dmn"})
 public class _0030UserDefinedFunctionsTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.1/cl3/0031-static-user-defined-functions/translator/expected/java/test/Test0031UserDefinedFunctions.java
+++ b/dmn-test-cases/standard/tck/1.1/cl3/0031-static-user-defined-functions/translator/expected/java/test/Test0031UserDefinedFunctions.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0031-user-defined-functions.dmn"})
 public class Test0031UserDefinedFunctions extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.annotation.AnnotationSet annotationSet_ = new com.gs.dmn.runtime.annotation.AnnotationSet();
         com.gs.dmn.runtime.listener.EventListener eventListener_ = new com.gs.dmn.runtime.listener.NopEventListener();
@@ -18,7 +18,7 @@ public class Test0031UserDefinedFunctions extends com.gs.dmn.runtime.DefaultDMNB
         checkValues(new type.TFnInvocationPositionalResultImpl(number("2"), number("50"), number("15")), new FnInvocationPositionalParameters().apply(inputA, inputB, annotationSet_, eventListener_, externalExecutor_, cache_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase002() {
         com.gs.dmn.runtime.annotation.AnnotationSet annotationSet_ = new com.gs.dmn.runtime.annotation.AnnotationSet();
         com.gs.dmn.runtime.listener.EventListener eventListener_ = new com.gs.dmn.runtime.listener.NopEventListener();
@@ -32,7 +32,7 @@ public class Test0031UserDefinedFunctions extends com.gs.dmn.runtime.DefaultDMNB
         checkValues(new type.TFnInvocationNamedResultImpl(number("2"), number("50"), number("5"), number("-5")), new FnInvocationNamedParameters().apply(inputA, inputB, annotationSet_, eventListener_, externalExecutor_, cache_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase003() {
         com.gs.dmn.runtime.annotation.AnnotationSet annotationSet_ = new com.gs.dmn.runtime.annotation.AnnotationSet();
         com.gs.dmn.runtime.listener.EventListener eventListener_ = new com.gs.dmn.runtime.listener.NopEventListener();

--- a/dmn-test-cases/standard/tck/1.1/cl3/0031-user-defined-functions/translator/expected/java/test/_0031UserDefinedFunctionsTest.java
+++ b/dmn-test-cases/standard/tck/1.1/cl3/0031-user-defined-functions/translator/expected/java/test/_0031UserDefinedFunctionsTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0031-user-defined-functions.dmn"})
 public class _0031UserDefinedFunctionsTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -16,7 +16,7 @@ public class _0031UserDefinedFunctionsTest extends com.gs.dmn.runtime.DefaultDMN
         checkValues(new type.TFnInvocationPositionalResultImpl(number("2"), number("50"), number("15")), new FnInvocationPositionalParameters().apply(inputA, inputB, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase002() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -28,7 +28,7 @@ public class _0031UserDefinedFunctionsTest extends com.gs.dmn.runtime.DefaultDMN
         checkValues(new type.TFnInvocationNamedResultImpl(number("2"), number("50"), number("5"), number("-5")), new FnInvocationNamedParameters().apply(inputA, inputB, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase003() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.1/cl3/9001-recursive-function/translator/expected/java/test/_9001RecursiveFunctionTest.java
+++ b/dmn-test-cases/standard/tck/1.1/cl3/9001-recursive-function/translator/expected/java/test/_9001RecursiveFunctionTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "9001-recursive-function.dmn"})
 public class _9001RecursiveFunctionTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -15,7 +15,7 @@ public class _9001RecursiveFunctionTest extends com.gs.dmn.runtime.DefaultDMNBas
         checkValues(number("1"), new Main().apply(n, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase002() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -26,7 +26,7 @@ public class _9001RecursiveFunctionTest extends com.gs.dmn.runtime.DefaultDMNBas
         checkValues(number("1"), new Main().apply(n, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase003() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -37,7 +37,7 @@ public class _9001RecursiveFunctionTest extends com.gs.dmn.runtime.DefaultDMNBas
         checkValues(number("6"), new Main().apply(n, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase004() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.2/cl3/0076-feel-external-java/translator/expected/java/test/_0076FeelExternalJavaTest.java
+++ b/dmn-test-cases/standard/tck/1.2/cl3/0076-feel-external-java/translator/expected/java/test/_0076FeelExternalJavaTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0076-feel-external-java.dmn"})
 public class _0076FeelExternalJavaTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCaseboxed_001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -13,7 +13,7 @@ public class _0076FeelExternalJavaTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues(number("456"), new Boxed_001().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCaseincorrect_001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -22,7 +22,7 @@ public class _0076FeelExternalJavaTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues(null, new Incorrect_001().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCaseincorrect_002() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -31,7 +31,7 @@ public class _0076FeelExternalJavaTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues(null, new Incorrect_002().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCaseincorrect_003() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -40,7 +40,7 @@ public class _0076FeelExternalJavaTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues(null, new Incorrect_003().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCaseliteral_001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -49,7 +49,7 @@ public class _0076FeelExternalJavaTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues(number("-0.88796890"), new Literal_001().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCaseliteral_002() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -58,7 +58,7 @@ public class _0076FeelExternalJavaTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues(number("456.78"), new Literal_002().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCaseliteral_003() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -67,7 +67,7 @@ public class _0076FeelExternalJavaTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues(number("456"), new Literal_003().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCaseliteral_004() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -76,7 +76,7 @@ public class _0076FeelExternalJavaTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues(number("456"), new Literal_004().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCaseliteral_005() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -85,7 +85,7 @@ public class _0076FeelExternalJavaTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues(number("123"), new Literal_005().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCaseliteral_006() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -94,7 +94,7 @@ public class _0076FeelExternalJavaTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues(number("3"), new Literal_006().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCaseliteral_007() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -103,7 +103,7 @@ public class _0076FeelExternalJavaTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues("a", new Literal_007().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCaseliteral_007_a() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -112,7 +112,7 @@ public class _0076FeelExternalJavaTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues(null, new Literal_007_a().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCaseliteral_008() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -121,7 +121,7 @@ public class _0076FeelExternalJavaTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues(number("456"), new Literal_008().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCaseliteral_009() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -130,7 +130,7 @@ public class _0076FeelExternalJavaTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues(number("456.78"), new Literal_009().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCaseliteral_010() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -139,7 +139,7 @@ public class _0076FeelExternalJavaTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues(number("123"), new Literal_010().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCaseliteral_011() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -148,7 +148,7 @@ public class _0076FeelExternalJavaTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues(number("1234.56"), new Literal_011().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCaseliteral_012() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -157,7 +157,7 @@ public class _0076FeelExternalJavaTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues(number("1234.56"), new Literal_012().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCasevarargs_001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.3/cl3/0004-lending/translator/expected/java/test/_0004LendingTest.java
+++ b/dmn-test-cases/standard/tck/1.3/cl3/0004-lending/translator/expected/java/test/_0004LendingTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0004-lending.dmn"})
 public class _0004LendingTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.3/cl3/0020-vacation-days/translator/expected/aws/dmn/f0020vacationdays/pom.xml
+++ b/dmn-test-cases/standard/tck/1.3/cl3/0020-vacation-days/translator/expected/aws/dmn/f0020vacationdays/pom.xml
@@ -76,8 +76,8 @@
            <scope>test</scope>
         </dependency>
         <dependency>
-           <groupId>org.junit.vintage</groupId>
-           <artifactId>junit-vintage-engine</artifactId>
+           <groupId>org.junit.jupiter</groupId>
+           <artifactId>junit-jupiter-engine</artifactId>
            <version>5.10.1</version>
            <scope>test</scope>
         </dependency>

--- a/dmn-test-cases/standard/tck/1.3/cl3/0085-decision-services/translator/expected/java/test/_0085DecisionServicesTest.java
+++ b/dmn-test-cases/standard/tck/1.3/cl3/0085-decision-services/translator/expected/java/test/_0085DecisionServicesTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0085-decision-services.dmn"})
 public class _0085DecisionServicesTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -13,7 +13,7 @@ public class _0085DecisionServicesTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues("foo", DecisionService_001.instance().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase002() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -25,7 +25,7 @@ public class _0085DecisionServicesTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues("foo baz", DecisionService_002.instance().apply(decision_002_input, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase003() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -40,7 +40,7 @@ public class _0085DecisionServicesTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues("A B C D", DecisionService_003.instance().apply(inputData_003, decision_003_input_1, decision_003_input_2, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase004() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -49,7 +49,7 @@ public class _0085DecisionServicesTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues("foo", new Decision_004_1().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase006() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -58,7 +58,7 @@ public class _0085DecisionServicesTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues("foo bar", new Decision_006_1().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase009() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -67,7 +67,7 @@ public class _0085DecisionServicesTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues("foo bar", new Decision_009_1().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase011() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -76,7 +76,7 @@ public class _0085DecisionServicesTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues("A B C D", new Decision_011_1().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase012() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -85,7 +85,7 @@ public class _0085DecisionServicesTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues("A B C D", new Decision_012_1().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase013() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -96,7 +96,7 @@ public class _0085DecisionServicesTest extends com.gs.dmn.runtime.DefaultDMNBase
         checkValues(new com.gs.dmn.runtime.Context().add("decisionService_013", "A B").add("decision_013_3", "D").add("inputData_013_1", "C"), new Decision_013_1().apply(inputData_013_1, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase014() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/dmn-test-cases/standard/tck/1.3/cl3/0092-feel-lambda/translator/expected/java/test/_0092FeelLambdaTest.java
+++ b/dmn-test-cases/standard/tck/1.3/cl3/0092-feel-lambda/translator/expected/java/test/_0092FeelLambdaTest.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 @javax.annotation.Generated(value = {"junit.ftl", "0092-feel-lambda.dmn"})
 public class _0092FeelLambdaTest extends com.gs.dmn.runtime.DefaultDMNBaseDecision {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase001() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -13,7 +13,7 @@ public class _0092FeelLambdaTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisi
         checkValues(number("3"), new Decision_001_1().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase002() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -22,7 +22,7 @@ public class _0092FeelLambdaTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisi
         checkValues(number("4"), new Decision_002_1().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase003() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -31,7 +31,7 @@ public class _0092FeelLambdaTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisi
         checkValues(number("5"), new Decision_003_1().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase004() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -40,7 +40,7 @@ public class _0092FeelLambdaTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisi
         checkValues(number("6"), new Decision_004_1().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase005() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -49,7 +49,7 @@ public class _0092FeelLambdaTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisi
         checkValues(number("20"), new Decision_005_1().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase006() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -58,7 +58,7 @@ public class _0092FeelLambdaTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisi
         checkValues(number("30"), new Decision_006_1().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase007() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -69,7 +69,7 @@ public class _0092FeelLambdaTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisi
         checkValues(number("100"), new Decision_007_1().apply(input_007_1, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase008() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -78,7 +78,7 @@ public class _0092FeelLambdaTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisi
         checkValues(number("6"), new Decision_008_1().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase009() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -87,7 +87,7 @@ public class _0092FeelLambdaTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisi
         checkValues(number("200"), new Decision_009_1().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase010() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -96,7 +96,7 @@ public class _0092FeelLambdaTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisi
         checkValues(number("120"), new Decision_010_1().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase010_a() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -105,7 +105,7 @@ public class _0092FeelLambdaTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisi
         checkValues(number("120"), new Decision_010_1_a().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase011() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -116,7 +116,7 @@ public class _0092FeelLambdaTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisi
         checkValues(number("5000"), new Decision_011_1().apply(input_011_1, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase012() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -125,7 +125,7 @@ public class _0092FeelLambdaTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisi
         checkValues(number("5000"), new Decision_012_1().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase013() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -134,7 +134,7 @@ public class _0092FeelLambdaTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisi
         checkValues(number("5000"), new Decision_013_1().apply(context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase017() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();
@@ -145,7 +145,7 @@ public class _0092FeelLambdaTest extends com.gs.dmn.runtime.DefaultDMNBaseDecisi
         checkValues(asList("a", "a", "z", "z"), new Decision_017_1().apply(input_017_1, context_));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testCase018() {
         com.gs.dmn.runtime.ExecutionContext context_ = new com.gs.dmn.runtime.ExecutionContext();
         com.gs.dmn.runtime.cache.Cache cache_ = context_.getCache();

--- a/pom.xml
+++ b/pom.xml
@@ -426,8 +426,8 @@ specific language governing permissions and limitations under the License.]]></i
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.junit.vintage</groupId>
-                <artifactId>junit-vintage-engine</artifactId>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
                 <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
@@ -490,8 +490,8 @@ specific language governing permissions and limitations under the License.]]></i
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
This PR upgrades usages of Junit 4 to Junit 5. In particular:
- The `junit-vintage-engine` dependency is replaced with the `junit-jupiter-engine` dependency in all `pom.xml` files in which it appears.
    - An exception to this is that we retain `junit-vintange-engine` in `dmn-core/pom.xml` due to the `FEELSuiteIT.java` test file. This file uses the `FitNesse` Runner, and `FitNesse` does not provide an equivalent mechanism that conforms to Junit 5's Extension model.
- Update json test resources to use `""` instead of `"\"\""` for empty annotations. The tests using these resources were not being run before, but with the introduction of the `jupiter-engine`, they are now running and failing due to the use of `"\"\""`. The assumption is that `""` is the correct format for specifying an empty annotation, ensuring consistency across test resources and fixing the test failures.
- Update the template `ftl` files and corresponding test files under `dmn-test-cases` to use `@org.junit.jupiter.api.Test` annotations instead of `@org.junit.Test`
- We update any Junit 4 import statements and expressions in the remaining `java` test files.