### PR TITLE
Fix NPE in PositionalParameterTypes.toString() when element type.toString() throws

### DIFF
--- a/dmn-core/src/main/java/com/gs/dmn/feel/analysis/syntax/ast/expression/function/PositionalParameterTypes.java
+++ b/dmn-core/src/main/java/com/gs/dmn/feel/analysis/syntax/ast/expression/function/PositionalParameterTypes.java
@@ -50,7 +50,15 @@ public class PositionalParameterTypes<T> extends ParameterTypes<T> {
 
     @Override
     public String toString() {
-        String opd = this.types.stream().map(t -> String.format("%s", t)).collect(Collectors.joining(", "));
+        String opd = this.types.stream()
+                .map(t -> {
+                    try {
+                        return String.format("%s", t);
+                    } catch (RuntimeException e) {
+                        return "?";
+                    }
+                })
+                .collect(Collectors.joining(", "));
         return String.format("%s(%s)", getClass().getSimpleName(), opd);
     }
 }

--- a/dmn-core/src/test/java/com/gs/dmn/feel/analysis/syntax/ast/expression/function/PositionalParameterTypesTest.java
+++ b/dmn-core/src/test/java/com/gs/dmn/feel/analysis/syntax/ast/expression/function/PositionalParameterTypesTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Goldman Sachs.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.gs.dmn.feel.analysis.syntax.ast.expression.function;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class PositionalParameterTypesTest {
+
+    @Test
+    void toString_does_not_propagate_exception_from_element_toString() {
+        // Reproduces: NPE propagated from PositionalParameterTypes.toString() when a
+        // Type element's own toString() throws. This occurred during error-message
+        // formatting in FunctionInvocationUtils.functionResolution(), masking the
+        // original type-resolution failure with an uninformative NullPointerException.
+        Object faultyType = new Object() {
+            @Override
+            public String toString() {
+                throw new NullPointerException("null field inside type");
+            }
+        };
+
+        PositionalParameterTypes<Object> params =
+                new PositionalParameterTypes<>(List.of(faultyType));
+
+        assertDoesNotThrow(params::toString);
+    }
+
+    @Test
+    void toString_handles_null_element() {
+        PositionalParameterTypes<Object> params =
+                new PositionalParameterTypes<>(Arrays.asList(null, "SomeType"));
+
+        assertDoesNotThrow(params::toString);
+    }
+}


### PR DESCRIPTION
## Problem

  When a FEEL function is called with a variable whose type cannot be resolved
  from the environment (e.g. `contains(?, "X")` where `?` is bound at runtime
  but not declared with a type in the Environment), jDMN's semantic analyser
  tries to report a helpful "Cannot resolve function" error in
  `FunctionInvocationUtils.functionResolution()`.

  The error message is formatted using `PositionalParameterTypes.toString()`,
  which streams over parameter types and calls `String.format("%s", t)` on each.
  If any type object's own `toString()` throws `NullPointerException` (e.g.
  because it references a null field), the exception propagates uncaught — and
  the caller sees a meaningless NPE instead of the intended `DMNRuntimeException`.

  Stack trace (abridged):
  java.lang.NullPointerException
    at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
    at com.gs.dmn.feel.analysis.syntax.ast.expression.function.PositionalParameterTypes.toString(PositionalParameterTypes.java:53)
    at java.util.Formatter$FormatSpecifier.printString(Formatter.java:3158)
    at com.gs.dmn.feel.analysis.semantics.FunctionInvocationUtils.functionResolution(FunctionInvocationUtils.java:235)

  ## Fix

  Made `PositionalParameterTypes.toString()` defensive: catch `RuntimeException`
  inside the stream mapping so that error message formatting never itself throws.

  ## Note

  The root cause — that an unresolved variable's Type object has a null field in
  its `toString()` — may warrant a follow-up fix in the relevant Type implementation.