### PR TITLE
Add DCO for Patrick Ribbsaeter

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -6,3 +6,4 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 This product contains code copyright Cerebral Adaptive Forecasting, licensed under Apache 2.0 license.
+This product contains code copyright Patrick Ribbsaeter, licensed under Apache 2.0 license.

--- a/dco/patrick_ribbsaeter.dco
+++ b/dco/patrick_ribbsaeter.dco
@@ -1,0 +1,9 @@
+1) I, Patrick Ribbsaeter, certify that all work committed with the commit message
+"covered by: patrick_ribbsaeter.dco" is my original work and I own the copyright
+to this work. I agree to contribute this code under the Apache 2.0 license.
+
+2) I understand and agree all contribution including all personal
+information I submit with it is maintained indefinitely and may be
+redistributed consistent with the open source license(s) involved.
+
+This certification is effective for all code contributed from 2026-08-03 to 9999-01-01.


### PR DESCRIPTION
## Summary

- add Patrick Ribbsaeter's Developer Certificate of Origin
- register the corresponding copyright notice

This establishes the contribution authorization required before submitting code to jDMN.
