### PR TITLE
Add decision table lazy evaluation detector

### DIFF
--- a/dmn-core/src/main/java/com/gs/dmn/transformation/lazy/DecisionTableLazyEvaluationDetector.java
+++ b/dmn-core/src/main/java/com/gs/dmn/transformation/lazy/DecisionTableLazyEvaluationDetector.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Patrick Ribbsaeter.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.gs.dmn.transformation.lazy;
+
+import com.gs.dmn.DMNModelRepository;
+import com.gs.dmn.DRGElementReference;
+import com.gs.dmn.ast.TDecision;
+import com.gs.dmn.log.BuildLogger;
+import com.gs.dmn.log.Slf4jBuildLogger;
+import com.gs.dmn.transformation.InputParameters;
+
+public class DecisionTableLazyEvaluationDetector extends SimpleLazyEvaluationDetector {
+    public DecisionTableLazyEvaluationDetector() {
+        this(new InputParameters(), new Slf4jBuildLogger(LOGGER));
+    }
+
+    public DecisionTableLazyEvaluationDetector(InputParameters inputParameters, BuildLogger logger) {
+        super(logger, inputParameters);
+    }
+
+    @Override
+    public LazyEvaluationOptimisation detect(DMNModelRepository modelRepository) {
+        LazyEvaluationOptimisation lazyEvaluationOptimisation = new LazyEvaluationOptimisation();
+
+        logger.info("Scanning decision tables for child decisions ...");
+
+        for (TDecision decision : modelRepository.findAllDecisions()) {
+            if (modelRepository.isDecisionTableExpression(decision)) {
+                for (DRGElementReference<TDecision> reference : modelRepository.directSubDecisions(decision)) {
+                    lazyEvaluationOptimisation.addLazyEvaluatedDecision(modelRepository.lazyEvaluationKey(reference.getElement()));
+                }
+            }
+        }
+
+        logger.info(String.format("Decisions to be lazy evaluated: '%s'", String.join(", ", lazyEvaluationOptimisation.getLazyEvaluatedDecisions())));
+
+        return lazyEvaluationOptimisation;
+    }
+}

--- a/dmn-core/src/test/java/com/gs/dmn/transformation/lazy/DecisionTableLazyEvaluationDetectorTest.java
+++ b/dmn-core/src/test/java/com/gs/dmn/transformation/lazy/DecisionTableLazyEvaluationDetectorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Patrick Ribbsaeter.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.gs.dmn.transformation.lazy;
+
+import com.gs.dmn.AbstractTest;
+import com.gs.dmn.DMNModelRepository;
+import com.gs.dmn.ast.TDefinitions;
+import com.gs.dmn.serialization.DMNSerializer;
+import com.gs.dmn.serialization.xstream.XMLDMNSerializer;
+import com.gs.dmn.transformation.InputParameters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class DecisionTableLazyEvaluationDetectorTest extends AbstractTest {
+    private static final List<String> EXPECTED_DECISIONS = List.of(
+            "http://www.trisotech.com/definitions/_4e0f0b70-d31c-471c-bd52-5ca709ed362b#BureauCallType",
+            "http://www.trisotech.com/definitions/_4e0f0b70-d31c-471c-bd52-5ca709ed362b#Eligibility"
+    );
+
+    private DMNModelRepository dmnModelRepository;
+    private final DMNSerializer dmnReader = new XMLDMNSerializer(LOGGER, this.inputParameters);
+
+    @BeforeEach
+    public void setUp() {
+        this.dmnModelRepository = readDMN("dmn/input/1.1/0004-lending.dmn");
+    }
+
+    @Test
+    public void testLazyEvaluationOptimisationWithDefaultConstructor() {
+        DecisionTableLazyEvaluationDetector detector = new DecisionTableLazyEvaluationDetector();
+
+        LazyEvaluationOptimisation optimisation = detector.detect(this.dmnModelRepository);
+
+        assertEquals(EXPECTED_DECISIONS, new ArrayList<>(optimisation.getLazyEvaluatedDecisions()));
+        assertFalse(optimisation.isLazyEvaluated(
+                "http://www.trisotech.com/definitions/_4e0f0b70-d31c-471c-bd52-5ca709ed362b#Pre-bureauRiskCategory"
+        ));
+    }
+
+    @Test
+    public void testLazyEvaluationOptimisation() {
+        DecisionTableLazyEvaluationDetector detector = new DecisionTableLazyEvaluationDetector(
+                new InputParameters(), LOGGER
+        );
+
+        LazyEvaluationOptimisation optimisation = detector.detect(this.dmnModelRepository);
+
+        assertEquals(EXPECTED_DECISIONS, new ArrayList<>(optimisation.getLazyEvaluatedDecisions()));
+    }
+
+    private DMNModelRepository readDMN(String pathName) {
+        File input = new File(resource(pathName));
+        TDefinitions definitions = this.dmnReader.readModel(input);
+        return new DMNModelRepository(definitions);
+    }
+}

--- a/docs/faq/translation.md
+++ b/docs/faq/translation.md
@@ -197,6 +197,17 @@ Configure the lazy evaluation detectors and the threshold.
 
 ```
 
+To lazily evaluate the direct child decisions of every decision table without applying a sparsity threshold, configure the decision table detector:
+
+```
+        . . .
+        <configuration>
+            <lazyEvaluationDetectors>
+                <lazyEvaluatorDetector>com.gs.dmn.transformation.lazy.DecisionTableLazyEvaluationDetector</lazyEvaluatorDetector>
+            </lazyEvaluationDetectors>
+        </configuration>
+```
+
 ### Lazy evaluation of Input Data
 
 In certain cases (e.g., input data is retrieved from a database and is used in a decision table with hit policy FIRST) it makes sense to retrieve child input data on demand. Module dmn-jpa-it contains an example for this optimization. 


### PR DESCRIPTION
## Summary

- add a lazy-evaluation detector for the direct child decisions of every decision table
- preserve namespace-qualified lazy-evaluation keys and deterministic de-duplication through the existing repository and optimisation APIs
- cover both reflective/default and injected construction, including the direct-child boundary
- document Maven configuration without requiring a sparsity threshold

## Why

The existing `SparseDecisionDetector` only applies when a decision table meets its configured sparsity threshold. This detector supports the issue's distinct use case: lazily evaluating direct child decisions for every decision-table decision.

## Validation

- `mvn -pl dmn-core -Dtest=DecisionTableLazyEvaluationDetectorTest,SparseDecisionDetectorTest,AllLazyEvaluationDetectorTest test` — 7 passed
- `mvn -pl dmn-core test` — 2,337 passed, 6 skipped
- `mvn clean install --show-version --batch-mode --errors` — full reactor passed; 8,985 reported tests, 8 skipped, zero failures/errors

Depends on DCO PR #817.

Fixes #816.
