### PR TITLE
Codegen runtime: drop commons-lang3 from runtime modules

### DIFF
--- a/dmn-runtime-api/pom.xml
+++ b/dmn-runtime-api/pom.xml
@@ -48,6 +48,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/dmn-runtime-api/src/main/java/com/gs/dmn/runtime/Context.java
+++ b/dmn-runtime-api/src/main/java/com/gs/dmn/runtime/Context.java
@@ -12,8 +12,11 @@
  */
 package com.gs.dmn.runtime;
 
-import org.apache.commons.lang3.SerializationUtils;
-
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.*;
 
@@ -22,10 +25,25 @@ public class Context implements Serializable {
         // shallow copy
         if (context != null) {
             Context deepCopy = new Context(context.name);
-            deepCopy.map.putAll(SerializationUtils.clone((LinkedHashMap) context.map));
+            deepCopy.map.putAll(deepClone((LinkedHashMap) context.map));
             return deepCopy;
         } else {
             return null;
+        }
+    }
+
+    private static LinkedHashMap deepClone(LinkedHashMap map) {
+        // deep clone via serialization round trip, values must be Serializable
+        try {
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+                out.writeObject(map);
+            }
+            try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+                return (LinkedHashMap) in.readObject();
+            }
+        } catch (IOException | ClassNotFoundException e) {
+            throw new IllegalStateException("Cannot clone context", e);
         }
     }
 

--- a/dmn-runtime-api/src/main/java/com/gs/dmn/runtime/StringUtils.java
+++ b/dmn-runtime-api/src/main/java/com/gs/dmn/runtime/StringUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Goldman Sachs.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.gs.dmn.runtime;
+
+public final class StringUtils {
+
+    private StringUtils() {
+    }
+
+    public static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    public static boolean isEmpty(String value) {
+        return value == null || value.isEmpty();
+    }
+
+    public static boolean isAlpha(String value) {
+        return value != null && !value.isEmpty() && value.codePoints().allMatch(Character::isLetter);
+    }
+
+    public static boolean isAlphanumeric(String value) {
+        return value != null && !value.isEmpty() && value.codePoints().allMatch(Character::isLetterOrDigit);
+    }
+
+    public static boolean isNumeric(String value) {
+        return value != null && !value.isEmpty() && value.codePoints().allMatch(Character::isDigit);
+    }
+}

--- a/dmn-runtime-api/src/main/java/com/gs/dmn/runtime/annotation/AnnotationSet.java
+++ b/dmn-runtime-api/src/main/java/com/gs/dmn/runtime/annotation/AnnotationSet.java
@@ -12,7 +12,8 @@
  */
 package com.gs.dmn.runtime.annotation;
 
-import org.apache.commons.lang3.StringUtils;
+import com.gs.dmn.runtime.StringUtils;
+
 
 import java.util.LinkedHashSet;
 import java.util.LinkedList;

--- a/dmn-runtime-api/src/main/java/com/gs/dmn/runtime/discovery/ModelElementRegistry.java
+++ b/dmn-runtime-api/src/main/java/com/gs/dmn/runtime/discovery/ModelElementRegistry.java
@@ -12,11 +12,12 @@
  */
 package com.gs.dmn.runtime.discovery;
 
+import com.gs.dmn.runtime.StringUtils;
+
 import com.gs.dmn.runtime.DMNRuntimeException;
 import com.gs.dmn.runtime.ExecutableDRGElement;
 import com.gs.dmn.runtime.annotation.DRGElement;
 import com.gs.dmn.runtime.annotation.DRGElementKind;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/StringEscapeUtil.java
+++ b/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/StringEscapeUtil.java
@@ -12,7 +12,8 @@
  */
 package com.gs.dmn.feel.lib;
 
-import org.apache.commons.lang3.StringUtils;
+import com.gs.dmn.runtime.StringUtils;
+
 
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/reference/TypeReference.java
+++ b/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/reference/TypeReference.java
@@ -12,8 +12,9 @@
  */
 package com.gs.dmn.feel.lib.reference;
 
+import com.gs.dmn.runtime.StringUtils;
+
 import com.gs.dmn.runtime.DMNRuntimeException;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
 

--- a/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/numeric/BaseNumericLib.java
+++ b/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/numeric/BaseNumericLib.java
@@ -12,7 +12,8 @@
  */
 package com.gs.dmn.feel.lib.type.numeric;
 
-import org.apache.commons.lang3.StringUtils;
+import com.gs.dmn.runtime.StringUtils;
+
 
 import java.util.Arrays;
 import java.util.List;

--- a/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/numeric/DecimalNumericLib.java
+++ b/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/numeric/DecimalNumericLib.java
@@ -12,8 +12,9 @@
  */
 package com.gs.dmn.feel.lib.type.numeric;
 
+import com.gs.dmn.runtime.StringUtils;
+
 import com.gs.dmn.runtime.DMNRuntimeException;
-import org.apache.commons.lang3.StringUtils;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;

--- a/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/numeric/DoubleNumericLib.java
+++ b/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/numeric/DoubleNumericLib.java
@@ -12,8 +12,9 @@
  */
 package com.gs.dmn.feel.lib.type.numeric;
 
+import com.gs.dmn.runtime.StringUtils;
+
 import com.gs.dmn.runtime.DMNRuntimeException;
-import org.apache.commons.lang3.StringUtils;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;

--- a/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/range/DefaultRangeLib.java
+++ b/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/range/DefaultRangeLib.java
@@ -12,6 +12,8 @@
  */
 package com.gs.dmn.feel.lib.type.range;
 
+import com.gs.dmn.runtime.StringUtils;
+
 import com.gs.dmn.feel.lib.JavaTimeFEELLib;
 import com.gs.dmn.feel.lib.StandardFEELLib;
 import com.gs.dmn.feel.lib.type.ComparableComparator;
@@ -28,7 +30,6 @@ import com.gs.dmn.feel.lib.type.time.xml.DefaultDurationComparator;
 import com.gs.dmn.runtime.DMNRuntimeException;
 import com.gs.dmn.runtime.Pair;
 import com.gs.dmn.runtime.Range;
-import org.apache.commons.lang3.StringUtils;
 
 import javax.xml.datatype.Duration;
 import java.math.BigDecimal;

--- a/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/time/BaseDateTimeLib.java
+++ b/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/time/BaseDateTimeLib.java
@@ -12,8 +12,9 @@
  */
 package com.gs.dmn.feel.lib.type.time;
 
+import com.gs.dmn.runtime.StringUtils;
+
 import com.gs.dmn.runtime.DMNRuntimeException;
-import org.apache.commons.lang3.StringUtils;
 
 import javax.xml.datatype.DatatypeConstants;
 import java.text.DateFormatSymbols;

--- a/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/time/mixed/MixedDateTimeLib.java
+++ b/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/time/mixed/MixedDateTimeLib.java
@@ -12,12 +12,13 @@
  */
 package com.gs.dmn.feel.lib.type.time.mixed;
 
+import com.gs.dmn.runtime.StringUtils;
+
 import com.gs.dmn.feel.lib.type.time.BaseDateTimeLib;
 import com.gs.dmn.feel.lib.type.time.DateTimeLib;
 import com.gs.dmn.feel.lib.type.time.xml.DefaultDurationComparator;
 import com.gs.dmn.feel.lib.type.time.xml.XMLDurationFactory;
 import com.gs.dmn.runtime.DMNRuntimeException;
-import org.apache.commons.lang3.StringUtils;
 
 import javax.xml.datatype.Duration;
 import java.math.BigDecimal;

--- a/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/time/pure/TemporalAmountDurationLib.java
+++ b/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/time/pure/TemporalAmountDurationLib.java
@@ -12,9 +12,10 @@
  */
 package com.gs.dmn.feel.lib.type.time.pure;
 
+import com.gs.dmn.runtime.StringUtils;
+
 import com.gs.dmn.feel.lib.type.time.DurationLib;
 import com.gs.dmn.runtime.DMNRuntimeException;
-import org.apache.commons.lang3.StringUtils;
 
 import java.time.Duration;
 import java.time.LocalDate;

--- a/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/time/pure/TemporalDateTimeLib.java
+++ b/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/time/pure/TemporalDateTimeLib.java
@@ -12,10 +12,11 @@
  */
 package com.gs.dmn.feel.lib.type.time.pure;
 
+import com.gs.dmn.runtime.StringUtils;
+
 import com.gs.dmn.feel.lib.type.time.BaseDateTimeLib;
 import com.gs.dmn.feel.lib.type.time.DateTimeLib;
 import com.gs.dmn.runtime.DMNRuntimeException;
-import org.apache.commons.lang3.StringUtils;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;

--- a/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/time/xml/XMLDurationFactory.java
+++ b/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/time/xml/XMLDurationFactory.java
@@ -12,8 +12,9 @@
  */
 package com.gs.dmn.feel.lib.type.time.xml;
 
+import com.gs.dmn.runtime.StringUtils;
+
 import com.gs.dmn.runtime.DMNRuntimeException;
-import org.apache.commons.lang3.StringUtils;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;

--- a/dmn-runtime/src/main/java/com/gs/dmn/runtime/Assert.java
+++ b/dmn-runtime/src/main/java/com/gs/dmn/runtime/Assert.java
@@ -14,7 +14,6 @@ package com.gs.dmn.runtime;
 
 import com.gs.dmn.feel.lib.type.BaseType;
 import com.gs.dmn.feel.lib.type.time.xml.BaseDefaultDurationType;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
 
 import javax.xml.datatype.Duration;

--- a/dmn-runtime/src/main/java/com/gs/dmn/runtime/Range.java
+++ b/dmn-runtime/src/main/java/com/gs/dmn/runtime/Range.java
@@ -12,7 +12,6 @@
  */
 package com.gs.dmn.runtime;
 
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.Objects;
 

--- a/dmn-runtime/src/main/java/com/gs/dmn/runtime/coverage/trace/ModelCoverageTrace.java
+++ b/dmn-runtime/src/main/java/com/gs/dmn/runtime/coverage/trace/ModelCoverageTrace.java
@@ -12,8 +12,9 @@
  */
 package com.gs.dmn.runtime.coverage.trace;
 
+import com.gs.dmn.runtime.StringUtils;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.Map;

--- a/dmn-runtime/src/main/java/com/gs/dmn/signavio/feel/lib/type/string/DefaultSignavioStringLib.java
+++ b/dmn-runtime/src/main/java/com/gs/dmn/signavio/feel/lib/type/string/DefaultSignavioStringLib.java
@@ -12,9 +12,10 @@
  */
 package com.gs.dmn.signavio.feel.lib.type.string;
 
+import com.gs.dmn.runtime.StringUtils;
+
 import com.gs.dmn.feel.lib.type.time.BaseDateTimeLib;
 import com.gs.dmn.signavio.feel.lib.SignavioUtil;
-import org.apache.commons.lang3.StringUtils;
 
 import java.math.BigDecimal;
 import java.text.DecimalFormat;


### PR DESCRIPTION
Replace StringUtils.isBlank/isEmpty/isAlpha/isAlphanumeric/isNumeric with a small StringUtils helper in dmn-runtime-api, and SerializationUtils.clone with a JDK serialization round trip. commons-lang3 remains test-scoped in dmn-runtime-api and untouched in the translator modules.