### PR TITLE
Codegen: make Jackson annotations in generated code optional

### DIFF
--- a/dmn-core/src/main/java/com/gs/dmn/transformation/InputParameters.java
+++ b/dmn-core/src/main/java/com/gs/dmn/transformation/InputParameters.java
@@ -109,6 +109,7 @@ public class InputParameters {
     private final boolean singletonDecision;
     // Whether to use strong typing during semantic analyses.
     private final boolean strongTyping;
+    private final boolean generateJsonAnnotations;
     // Whether to check constraints during evaluation / code generation.
     private final boolean checkConstraints;
 
@@ -171,6 +172,7 @@ public class InputParameters {
         // Translation and execution
         this.javaRootPackage = InputParameters.getOptionalParam(inputParameters, "javaRootPackage");
         this.onePackage = InputParameters.getOptionalBooleanParam(inputParameters, "onePackage", "false");
+        this.generateJsonAnnotations = InputParameters.getOptionalBooleanParam(inputParameters, "generateJsonAnnotations", "true");
         this.caching = InputParameters.getOptionalBooleanParam(inputParameters, "caching");
         String cachingThresholdParam = InputParameters.getOptionalParam(inputParameters, "cachingThreshold", "1");
         this.cachingThreshold = Integer.parseInt(cachingThresholdParam);
@@ -237,6 +239,10 @@ public class InputParameters {
 
     public boolean isStrongTyping() {
         return strongTyping;
+    }
+
+    public boolean isGenerateJsonAnnotations() {
+        return generateJsonAnnotations;
     }
 
     public boolean isRecursiveCalls() {

--- a/dmn-core/src/main/java/com/gs/dmn/transformation/basic/BasicDMNToJavaTransformer.java
+++ b/dmn-core/src/main/java/com/gs/dmn/transformation/basic/BasicDMNToJavaTransformer.java
@@ -185,6 +185,10 @@ public class BasicDMNToJavaTransformer implements BasicDMNToNativeTransformer<Ty
         return this.onePackage;
     }
 
+    public boolean isGenerateJsonAnnotations() {
+        return this.inputParameters.isGenerateJsonAnnotations();
+    }
+
     @Override
     public boolean isStrongTyping() {
         return this.inputParameters.isStrongTyping();

--- a/dmn-core/src/main/resources/templates/dmn/java/common/itemDefinitionClass.ftl
+++ b/dmn-core/src/main/resources/templates/dmn/java/common/itemDefinitionClass.ftl
@@ -17,7 +17,9 @@ package ${nativePackageName};
 import java.util.*;
 
 @javax.annotation.Generated(value = {"itemDefinition.ftl", "${modelRepository.name(itemDefinition)}"})
+<#if transformer.isGenerateJsonAnnotations()>
 @com.fasterxml.jackson.annotation.JsonPropertyOrder(alphabetic = true)
+</#if>
 public class ${nativeClassName} implements ${transformer.itemDefinitionNativeSimpleInterfaceName(nativeClassName)} {
     <@addFields itemDefinition />
 
@@ -50,12 +52,16 @@ public class ${nativeClassName} implements ${transformer.itemDefinitionNativeSim
     <#list itemDefinition.itemComponent as child>
         <#assign memberName = transformer.nativeVariableName(child)/>
         <#assign memberType = transformer.itemDefinitionNativeQualifiedInterfaceName(child)/>
+<#if transformer.isGenerateJsonAnnotations()>
     @com.fasterxml.jackson.annotation.JsonGetter("${transformer.escapeInString(modelRepository.displayName(child))}")
+</#if>
     public ${memberType} ${transformer.getter(child)} {
         return this.${memberName};
     }
 
+<#if transformer.isGenerateJsonAnnotations()>
     @com.fasterxml.jackson.annotation.JsonSetter("${transformer.escapeInString(modelRepository.displayName(child))}")
+</#if>
     public void ${transformer.setter(child, "${memberType} ${memberName}")} {
         this.${memberName} = ${memberName};
     }

--- a/dmn-core/src/main/resources/templates/dmn/java/common/itemDefinitionInterface.ftl
+++ b/dmn-core/src/main/resources/templates/dmn/java/common/itemDefinitionInterface.ftl
@@ -17,8 +17,12 @@ package ${nativePackageName};
 import java.util.*;
 
 @javax.annotation.Generated(value = {"itemDefinitionInterface.ftl", "${modelRepository.name(itemDefinition)}"})
+<#if transformer.isGenerateJsonAnnotations()>
 @com.fasterxml.jackson.annotation.JsonPropertyOrder(alphabetic = true)
+</#if>
+<#if transformer.isGenerateJsonAnnotations()>
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(as = ${serializationClass}.class)
+</#if>
 public interface ${nativeClassName} extends ${transformer.dmnTypeClassName()} {
     <@addConvertMethod itemDefinition />
 
@@ -69,7 +73,9 @@ public interface ${nativeClassName} extends ${transformer.dmnTypeClassName()} {
     <#list itemDefinition.itemComponent as child>
         <#assign memberName = transformer.nativeVariableName(child)/>
         <#assign memberType = transformer.itemDefinitionNativeQualifiedInterfaceName(child)/>
+<#if transformer.isGenerateJsonAnnotations()>
     @com.fasterxml.jackson.annotation.JsonGetter("${transformer.escapeInString(modelRepository.displayName(child))}")
+</#if>
     ${memberType} ${transformer.getter(child)};
 
     </#list>

--- a/dmn-core/src/main/resources/templates/dmn/java/tree/decisionTableRuleOutput.ftl
+++ b/dmn-core/src/main/resources/templates/dmn/java/tree/decisionTableRuleOutput.ftl
@@ -48,12 +48,16 @@ public class ${nativeClassName} extends ${transformer.abstractRuleOutputClassNam
 <#macro addAccessors drgElement>
     <#assign expression = modelRepository.expression(drgElement)>
     <#list expression.output as output>
+<#if transformer.isGenerateJsonAnnotations()>
     @com.fasterxml.jackson.annotation.JsonGetter("${transformer.escapeInString(transformer.outputClauseName(drgElement, output))}")
+</#if>
     public ${transformer.outputClauseClassName(drgElement, output, output?index)} ${transformer.outputClauseGetter(drgElement, output)} {
         return this.${transformer.outputClauseVariableName(drgElement, output)};
     }
 
+<#if transformer.isGenerateJsonAnnotations()>
     @com.fasterxml.jackson.annotation.JsonSetter("${transformer.escapeInString(transformer.outputClauseName(drgElement, output))}")
+</#if>
     <#assign outputClassName = transformer.outputClauseClassName(drgElement, output, output?index) />
     public void ${transformer.outputClauseSetter(drgElement, output, "${outputClassName} ${transformer.outputClauseVariableName(drgElement, output)}")} {
         this.${transformer.outputClauseVariableName(drgElement, output)} = ${transformer.outputClauseVariableName(drgElement, output)};

--- a/dmn-core/src/main/resources/templates/dmn/java/tree/elementInput.ftl
+++ b/dmn-core/src/main/resources/templates/dmn/java/tree/elementInput.ftl
@@ -17,7 +17,9 @@ package ${nativePackageName};
 import java.util.*;
 
 @javax.annotation.Generated(value = {"elementInput.ftl", "${transformer.escapeInString(modelRepository.name(drgElement))}"})
+<#if transformer.isGenerateJsonAnnotations()>
 @com.fasterxml.jackson.annotation.JsonPropertyOrder(alphabetic = true)
+</#if>
 public class ${nativeClassName} implements ${transformer.drgElementInputPojoInterfaceName()} {
     <#assign inputArguments = transformer.drgElementArgumentListInputPojo(drgElement) />
     <@addFields inputArguments />

--- a/dmn-core/src/main/resources/templates/dmn/kotlin/common/itemDefinitionClass.ftl
+++ b/dmn-core/src/main/resources/templates/dmn/kotlin/common/itemDefinitionClass.ftl
@@ -17,7 +17,9 @@ package ${nativePackageName}
 import java.util.*
 
 @javax.annotation.Generated(value = ["itemDefinition.ftl", "${modelRepository.name(itemDefinition)}"])
+<#if transformer.isGenerateJsonAnnotations()>
 @com.fasterxml.jackson.annotation.JsonPropertyOrder(alphabetic = true)
+</#if>
 class ${nativeClassName} : ${transformer.itemDefinitionNativeSimpleInterfaceName(nativeClassName)} {
     <@addFields itemDefinition />
     constructor() {
@@ -34,8 +36,12 @@ class ${nativeClassName} : ${transformer.itemDefinitionNativeSimpleInterfaceName
     <#list itemDefinition.itemComponent as child>
         <#assign memberName = transformer.nativeVariableName(child)/>
         <#assign memberType = transformer.itemDefinitionNativeQualifiedInterfaceName(child)/>
+<#if transformer.isGenerateJsonAnnotations()>
     @get:com.fasterxml.jackson.annotation.JsonGetter("${transformer.escapeInString(modelRepository.displayName(child))}")
+</#if>
+<#if transformer.isGenerateJsonAnnotations()>
     @set:com.fasterxml.jackson.annotation.JsonGetter("${transformer.escapeInString(modelRepository.displayName(child))}")
+</#if>
     override var ${memberName}: ${memberType} = null
 
     </#list>

--- a/dmn-core/src/main/resources/templates/dmn/kotlin/common/itemDefinitionInterface.ftl
+++ b/dmn-core/src/main/resources/templates/dmn/kotlin/common/itemDefinitionInterface.ftl
@@ -17,8 +17,12 @@ package ${nativePackageName}
 import java.util.*
 
 @javax.annotation.Generated(value = ["itemDefinitionInterface.ftl", "${modelRepository.name(itemDefinition)}"])
+<#if transformer.isGenerateJsonAnnotations()>
 @com.fasterxml.jackson.annotation.JsonPropertyOrder(alphabetic = true)
+</#if>
+<#if transformer.isGenerateJsonAnnotations()>
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(`as` = ${serializationClass}::class)
+</#if>
 interface ${nativeClassName} : ${transformer.dmnTypeClassName()} {
     <@addMembers itemDefinition />
     <@addToContext itemDefinition />
@@ -33,7 +37,9 @@ interface ${nativeClassName} : ${transformer.dmnTypeClassName()} {
     <#list itemDefinition.itemComponent as child>
         <#assign memberName = transformer.nativeVariableName(child)/>
         <#assign memberType = transformer.itemDefinitionNativeQualifiedInterfaceName(child)/>
+<#if transformer.isGenerateJsonAnnotations()>
     @get:com.fasterxml.jackson.annotation.JsonGetter("${transformer.escapeInString(modelRepository.displayName(child))}")
+</#if>
     val ${transformer.nativeVariableName(child)}: ${memberType}
 
     </#list>

--- a/dmn-core/src/main/resources/templates/dmn/kotlin/tree/decisionTableRuleOutput.ftl
+++ b/dmn-core/src/main/resources/templates/dmn/kotlin/tree/decisionTableRuleOutput.ftl
@@ -30,7 +30,9 @@ class ${nativeClassName}(matched: Boolean) : ${transformer.abstractRuleOutputCla
 <#macro addPrivateFields drgElement>
     <#assign expression = modelRepository.expression(drgElement)>
     <#list expression.output as output>
+<#if transformer.isGenerateJsonAnnotations()>
     @com.fasterxml.jackson.annotation.JsonProperty("${transformer.escapeInString(transformer.outputClauseName(drgElement, output))}")
+</#if>
     var ${transformer.outputClauseVariableName(drgElement, output)}: ${transformer.outputClauseClassName(drgElement, output, output?index)}? = null
     <#if modelRepository.isOutputOrderHit(expression.hitPolicy)>
     var ${transformer.outputClausePriorityVariableName(drgElement, output)}: Int? = 0


### PR DESCRIPTION
Add the boolean input parameter generateJsonAnnotations (default true). When set to false, the generated POJOs carry no Jackson annotations, so the generated code compiles and runs without any Jackson artifact on the classpath.