### PR TITLE
Codegen runtime: make Saxon-HE optional via pluggable regex engine

### DIFF
--- a/dmn-core/pom.xml
+++ b/dmn-core/pom.xml
@@ -44,6 +44,20 @@
 			<version>${project.version}</version>
 		</dependency>
 
+		<!-- Saxon-HE is optional in jdmn-runtime; the translator and interpreter
+		     keep the XPath-exact regex engine for replace()/matches()/split(). -->
+		<dependency>
+			<groupId>net.sf.saxon</groupId>
+			<artifactId>Saxon-HE</artifactId>
+			<version>11.4</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
 		<dependency>
 			<groupId>org.freemarker</groupId>
 			<artifactId>freemarker</artifactId>

--- a/dmn-runtime/pom.xml
+++ b/dmn-runtime/pom.xml
@@ -58,6 +58,9 @@
             <groupId>net.sf.saxon</groupId>
             <artifactId>Saxon-HE</artifactId>
             <version>11.4</version>
+            <!-- Optional: XPath-exact regex for replace()/matches()/split();
+                 JDK regex fallback otherwise (see RegexEvaluator). -->
+            <optional>true</optional>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/string/DefaultStringLib.java
+++ b/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/string/DefaultStringLib.java
@@ -13,7 +13,6 @@
 package com.gs.dmn.feel.lib.type.string;
 
 import com.gs.dmn.feel.lib.FormatUtils;
-import net.sf.saxon.s9api.*;
 
 import java.time.Duration;
 import java.time.temporal.TemporalAccessor;
@@ -244,51 +243,55 @@ public class DefaultStringLib implements StringLib {
     }
 
     private String evaluateReplace(String input, String pattern, String replacement, String flags) throws Exception {
-        String functionName = "replace";
-        List<String> paramNames = Arrays.asList("input", "pattern", "replacement", "flags");
-        List<String> arguments = Arrays.asList(input, pattern, replacement, flags);
-        XdmValue result = evaluateFunction(functionName, paramNames, arguments);
-        return ((XdmAtomicValue) result).getStringValue();
+        return regexEvaluator().evaluateReplace(input, pattern, replacement, flags);
     }
 
     private boolean evaluateMatches(String input, String pattern, String flags) throws Exception {
-        String functionName = "matches";
-        List<String> paramNames = Arrays.asList("input", "pattern", "flags");
-        List<String> arguments = Arrays.asList(input, pattern, flags);
-        XdmValue result = evaluateFunction(functionName, paramNames, arguments);
-        return ((XdmAtomicValue) result).getBooleanValue();
+        return regexEvaluator().evaluateMatches(input, pattern, flags);
     }
 
-    private List<String> evaluateSplit(String input, String pattern) throws SaxonApiException {
-        String functionName = "tokenize";
-        List<String> paramNames = Arrays.asList("input", "pattern");
-        List<String> arguments = Arrays.asList(input, pattern);
-        XdmValue result = evaluateFunction(functionName, paramNames, arguments);
-        // Iterate over the resulting tokens
-        return result.stream().map(XdmItem::getStringValue).collect(Collectors.toList());
+    private List<String> evaluateSplit(String input, String pattern) throws Exception {
+        return regexEvaluator().evaluateSplit(input, pattern);
     }
 
-    private static XdmValue evaluateFunction(String functionName, List<String> paramNames, List<String> arguments) throws SaxonApiException {
-        // Create a Saxon processor
-        Processor processor = new Processor(false);
-        XPathCompiler xpathCompiler = processor.newXPathCompiler();
+    /**
+     * System property selecting the regex engine for replace()/matches()/split():
+     * {@code saxon} (exact XPath F&amp;O semantics, requires Saxon-HE on the classpath),
+     * {@code jdk} (java.util.regex, no external dependency) or {@code auto}
+     * (default: Saxon if present, otherwise JDK).
+     */
+    public static final String REGEX_ENGINE_PROPERTY = "jdmn.regex.engine";
 
-        // Declare variables in the XPath expression
-        for (String param: paramNames) {
-            xpathCompiler.declareVariable(new QName(param));
+    private volatile RegexEvaluator regexEvaluator;
+
+    private RegexEvaluator regexEvaluator() {
+        RegexEvaluator evaluator = this.regexEvaluator;
+        if (evaluator == null) {
+            evaluator = createRegexEvaluator();
+            this.regexEvaluator = evaluator;
         }
+        return evaluator;
+    }
 
-        // Construct an XPath expression using the tokenize() function
-        String call = String.format("%s(%s)", functionName, paramNames.stream().map(p -> "$"+p).collect(Collectors.joining(", ")));
-        XPathExecutable compile = xpathCompiler.compile(call);
-        XPathSelector selector = compile.load();
-
-        // Set the input string and pattern as variables
-        for (int i = 0; i< paramNames.size(); i++) {
-            selector.setVariable(new QName(paramNames.get(i)), new XdmAtomicValue(arguments.get(i)));
+    private static RegexEvaluator createRegexEvaluator() {
+        String engine = System.getProperty(REGEX_ENGINE_PROPERTY, "auto");
+        switch (engine) {
+            case "jdk":
+                return new JdkRegexEvaluator();
+            case "saxon":
+                try {
+                    return new XPathRegexEvaluator();
+                } catch (LinkageError e) {
+                    throw new IllegalStateException("'" + REGEX_ENGINE_PROPERTY + "=saxon' requires Saxon-HE (net.sf.saxon:Saxon-HE) on the classpath", e);
+                }
+            case "auto":
+                try {
+                    return new XPathRegexEvaluator();
+                } catch (LinkageError e) {
+                    return new JdkRegexEvaluator();
+                }
+            default:
+                throw new IllegalArgumentException("Invalid value '" + engine + "' for system property '" + REGEX_ENGINE_PROPERTY + "', expected 'saxon', 'jdk' or 'auto'");
         }
-
-        // Evaluate the XPath expression
-        return selector.evaluate();
     }
 }

--- a/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/string/JdkRegexEvaluator.java
+++ b/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/string/JdkRegexEvaluator.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016 Goldman Sachs.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.gs.dmn.feel.lib.type.string;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Implements the FEEL string functions replace(), matches() and split() with
+ * {@code java.util.regex} — no external dependency.
+ *
+ * <p>The XPath flags are mapped to the corresponding {@link Pattern} flags:
+ * {@code i} → CASE_INSENSITIVE+UNICODE_CASE, {@code s} → DOTALL,
+ * {@code m} → MULTILINE, {@code x} → COMMENTS, {@code q} → LITERAL.
+ *
+ * <p>Known deviations from the XPath F&amp;O regex dialect required by the DMN
+ * specification:
+ * <ul>
+ *   <li>character class subtraction {@code [a-z-[aeiou]]} is not supported
+ *       (Java equivalent: {@code [a-z&&[^aeiou]]})</li>
+ *   <li>the XML character classes {@code \i} and {@code \c} are not supported</li>
+ *   <li>replacement strings that are invalid in XPath (escapes other than
+ *       {@code $N}, {@code \$}, {@code \\}) are not always rejected</li>
+ * </ul>
+ */
+class JdkRegexEvaluator implements RegexEvaluator {
+
+    @Override
+    public String evaluateReplace(String input, String pattern, String replacement, String flags) {
+        // XPath-valid replacements ($N, \$, \\) have identical semantics in
+        // Matcher.replaceAll, so the replacement string is passed through unchanged.
+        return compile(pattern, flags).matcher(input).replaceAll(replacement);
+    }
+
+    @Override
+    public boolean evaluateMatches(String input, String pattern, String flags) {
+        // fn:matches is unanchored, i.e. Matcher.find, not Matcher.matches
+        return compile(pattern, flags).matcher(input).find();
+    }
+
+    @Override
+    public List<String> evaluateSplit(String input, String pattern) {
+        Pattern compiled = compile(pattern, "");
+        if (compiled.matcher("").find()) {
+            // XPath error FORX0003: the tokenize pattern must not match the empty string
+            throw new IllegalArgumentException(
+                    "split() pattern '" + pattern + "' matches the empty string");
+        }
+        // limit -1 keeps trailing empty tokens, matching fn:tokenize
+        return Arrays.asList(compiled.split(input, -1));
+    }
+
+    private static Pattern compile(String pattern, String flags) {
+        int patternFlags = 0;
+        if (flags != null) {
+            for (char flag : flags.toCharArray()) {
+                switch (flag) {
+                    case 'i': patternFlags |= Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE; break;
+                    case 's': patternFlags |= Pattern.DOTALL; break;
+                    case 'm': patternFlags |= Pattern.MULTILINE; break;
+                    case 'x': patternFlags |= Pattern.COMMENTS; break;
+                    case 'q': patternFlags |= Pattern.LITERAL; break;
+                    default:
+                        // XPath error FORX0001: invalid regular expression flag
+                        throw new IllegalArgumentException(
+                                "Invalid regular expression flag '" + flag + "' in '" + flags + "'");
+                }
+            }
+        }
+        return Pattern.compile(pattern, patternFlags);
+    }
+}

--- a/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/string/RegexEvaluator.java
+++ b/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/string/RegexEvaluator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Goldman Sachs.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.gs.dmn.feel.lib.type.string;
+
+import java.util.List;
+
+/**
+ * Strategy for the regex-based FEEL string functions replace(), matches() and
+ * split(). Implementations: {@link XPathRegexEvaluator} (Saxon-HE, exact XPath
+ * F&amp;O semantics as required by the DMN specification) and
+ * {@link JdkRegexEvaluator} (java.util.regex, no external dependency).
+ *
+ * <p>The implementation is chosen by {@link DefaultStringLib} via the system
+ * property {@code jdmn.regex.engine} ({@code saxon}, {@code jdk} or
+ * {@code auto}; default {@code auto} = Saxon if present, otherwise JDK).
+ */
+interface RegexEvaluator {
+
+    String evaluateReplace(String input, String pattern, String replacement, String flags) throws Exception;
+
+    boolean evaluateMatches(String input, String pattern, String flags) throws Exception;
+
+    List<String> evaluateSplit(String input, String pattern) throws Exception;
+}

--- a/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/string/XPathRegexEvaluator.java
+++ b/dmn-runtime/src/main/java/com/gs/dmn/feel/lib/type/string/XPathRegexEvaluator.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016 Goldman Sachs.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.gs.dmn.feel.lib.type.string;
+
+import net.sf.saxon.s9api.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Implements the FEEL string functions replace(), matches() and split() with the
+ * exact XPath F&amp;O semantics required by the DMN specification, delegating to
+ * Saxon-HE.
+ *
+ * <p>This is the only class in the runtime that references Saxon. It is loaded
+ * lazily by {@link DefaultStringLib}, so Saxon-HE is an optional dependency that
+ * is only required when this evaluator is selected.
+ */
+class XPathRegexEvaluator implements RegexEvaluator {
+    // Saxon's Processor is thread-safe and expensive to create; share one instance.
+    private final Processor processor = new Processor(false);
+
+    @Override
+    public String evaluateReplace(String input, String pattern, String replacement, String flags) throws SaxonApiException {
+        String functionName = "replace";
+        List<String> paramNames = Arrays.asList("input", "pattern", "replacement", "flags");
+        List<String> arguments = Arrays.asList(input, pattern, replacement, flags);
+        XdmValue result = evaluateFunction(functionName, paramNames, arguments);
+        return ((XdmAtomicValue) result).getStringValue();
+    }
+
+    @Override
+    public boolean evaluateMatches(String input, String pattern, String flags) throws SaxonApiException {
+        String functionName = "matches";
+        List<String> paramNames = Arrays.asList("input", "pattern", "flags");
+        List<String> arguments = Arrays.asList(input, pattern, flags);
+        XdmValue result = evaluateFunction(functionName, paramNames, arguments);
+        return ((XdmAtomicValue) result).getBooleanValue();
+    }
+
+    @Override
+    public List<String> evaluateSplit(String input, String pattern) throws SaxonApiException {
+        String functionName = "tokenize";
+        List<String> paramNames = Arrays.asList("input", "pattern");
+        List<String> arguments = Arrays.asList(input, pattern);
+        XdmValue result = evaluateFunction(functionName, paramNames, arguments);
+        // Iterate over the resulting tokens
+        return result.stream().map(XdmItem::getStringValue).collect(Collectors.toList());
+    }
+
+    private XdmValue evaluateFunction(String functionName, List<String> paramNames, List<String> arguments) throws SaxonApiException {
+        XPathCompiler xpathCompiler = processor.newXPathCompiler();
+
+        // Declare variables in the XPath expression
+        for (String param: paramNames) {
+            xpathCompiler.declareVariable(new QName(param));
+        }
+
+        // Construct an XPath expression using the tokenize() function
+        String call = String.format("%s(%s)", functionName, paramNames.stream().map(p -> "$"+p).collect(Collectors.joining(", ")));
+        XPathExecutable compile = xpathCompiler.compile(call);
+        XPathSelector selector = compile.load();
+
+        // Set the input string and pattern as variables
+        for (int i = 0; i< paramNames.size(); i++) {
+            selector.setVariable(new QName(paramNames.get(i)), new XdmAtomicValue(arguments.get(i)));
+        }
+
+        // Evaluate the XPath expression
+        return selector.evaluate();
+    }
+}

--- a/dmn-runtime/src/test/java/com/gs/dmn/feel/lib/type/string/RegexEvaluatorTest.java
+++ b/dmn-runtime/src/test/java/com/gs/dmn/feel/lib/type/string/RegexEvaluatorTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016 Goldman Sachs.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.gs.dmn.feel.lib.type.string;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RegexEvaluatorTest {
+
+    private final RegexEvaluator saxon = new XPathRegexEvaluator();
+    private final RegexEvaluator jdk = new JdkRegexEvaluator();
+
+    @Test
+    public void testMatchesParity() throws Exception {
+        assertParityMatches("north-42", "^no.*-\\d+$", "");
+        assertParityMatches("north-42", "^south", "");
+        assertParityMatches("Widget", "widget", "i");
+        assertParityMatches("line one\nline two", "^line two", "m");
+        assertParityMatches("alpha\nbeta", "alpha.beta", "s");
+        assertParityMatches("3+4", "3+4", "q");
+        assertParityMatches("teal", " t e a l ", "x");
+        assertParityMatches("code-9911", "[0-9]{4}", "");
+        assertParityMatches("plain words", "\\d", "");
+    }
+
+    @Test
+    public void testReplaceParity() throws Exception {
+        assertParityReplace("aabbbaa", "b+", "-", "");
+        assertParityReplace("x1y2z3", "(\\d)", "<$1>", "");
+        assertParityReplace("2026-08-20", "(\\d{4})-(\\d{2})-(\\d{2})", "$3.$2.$1", "");
+        assertParityReplace("Row Row Row", "row", "boat", "i");
+    }
+
+    @Test
+    public void testSplitParity() throws Exception {
+        assertParitySplit("red|green|blue", "\\|");
+        assertParitySplit("k1=v1;k2=v2;", ";");
+        assertParitySplit(";leading", ";");
+        assertParitySplit("solo", ",");
+        assertParitySplit("a,,b", ",");
+    }
+
+    @Test
+    public void testJdkSplitRejectsPatternMatchingEmptyString() {
+        assertThrows(IllegalArgumentException.class, () -> jdk.evaluateSplit("abc", "x?"));
+    }
+
+    @Test
+    public void testJdkRejectsInvalidFlag() {
+        assertThrows(IllegalArgumentException.class, () -> jdk.evaluateMatches("abc", "a", "z"));
+    }
+
+    @Test
+    public void testEngineSelectionBySystemProperty() throws Exception {
+        String previous = System.setProperty(DefaultStringLib.REGEX_ENGINE_PROPERTY, "jdk");
+        try {
+            DefaultStringLib lib = new DefaultStringLib();
+            assertTrue(lib.matches("north-42", "^no.*-\\d+$", ""));
+            assertEquals(Arrays.asList("one", "two"), lib.split("one two", "\\s"));
+            assertEquals("20.08.2026", lib.replace("2026-08-20", "(\\d{4})-(\\d{2})-(\\d{2})", "$3.$2.$1", ""));
+        } finally {
+            restore(previous);
+        }
+        previous = System.setProperty(DefaultStringLib.REGEX_ENGINE_PROPERTY, "invalid");
+        try {
+            DefaultStringLib lib = new DefaultStringLib();
+            assertThrows(IllegalArgumentException.class, () -> lib.matches("north-42", "^no", ""));
+        } finally {
+            restore(previous);
+        }
+    }
+
+    private void restore(String previous) {
+        if (previous == null) {
+            System.clearProperty(DefaultStringLib.REGEX_ENGINE_PROPERTY);
+        } else {
+            System.setProperty(DefaultStringLib.REGEX_ENGINE_PROPERTY, previous);
+        }
+    }
+
+    private void assertParityMatches(String input, String pattern, String flags) throws Exception {
+        assertEquals(saxon.evaluateMatches(input, pattern, flags), jdk.evaluateMatches(input, pattern, flags),
+                "matches('" + input + "', '" + pattern + "', '" + flags + "')");
+    }
+
+    private void assertParityReplace(String input, String pattern, String replacement, String flags) throws Exception {
+        assertEquals(saxon.evaluateReplace(input, pattern, replacement, flags),
+                jdk.evaluateReplace(input, pattern, replacement, flags),
+                "replace('" + input + "', '" + pattern + "', '" + replacement + "', '" + flags + "')");
+    }
+
+    private void assertParitySplit(String input, String pattern) throws Exception {
+        List<String> expected = saxon.evaluateSplit(input, pattern);
+        List<String> actual = jdk.evaluateSplit(input, pattern);
+        assertEquals(expected, actual, "split('" + input + "', '" + pattern + "')");
+    }
+}


### PR DESCRIPTION
Move the Saxon code for replace()/matches()/split() behind a new RegexEvaluator interface and add a java.util.regex based fallback, so code generated by dmn-to-java runs without Saxon on the classpath. The engine is chosen via the system property jdmn.regex.engine (saxon|jdk|auto, default auto: Saxon if present, else JDK).